### PR TITLE
BACKLOG-16060: Sort deleted published URLs

### DIFF
--- a/src/javascript/components/VanityUrlEnabledContent.jsx
+++ b/src/javascript/components/VanityUrlEnabledContent.jsx
@@ -87,8 +87,13 @@ class VanityUrlEnabledContent extends React.Component {
                 <Button className={classes.showToggle} data-vud-role="button-filter-switch" variant="ghost" label={filterSwitchButtonLabel} onClick={e => this.handleFilterSwitchClick(e)}/>
             );
         }
-
         let vanityUrls = this.state.localFilteringEnabled || !content.allUrls ? content.urls : content.allUrls;
+
+        /** sort so that deleted published urls are listed at the end of vanity url list */
+        const deleted = [];
+        const others = [];
+        vanityUrls.forEach((url) => (url.live && !url.default) ? deleted.push(url) : others.push(url));
+        vanityUrls = [...others, ...deleted];
         return (
             <div className={this.props.classes.root} data-vud-content-uuid={content.uuid}>
                 <Paper elevation={1}>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16060
https://jira.jahia.org/browse/BACKLOG-16099

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added sorting so that deleted vanity URLs are added at the end of the list not at the beginning (since this seems to affect table column layout)

Before: 

![image](https://user-images.githubusercontent.com/75278792/122101783-b6510c80-cde2-11eb-9052-6e661196a851.png)


After: 

![image](https://user-images.githubusercontent.com/75278792/122101679-9ae60180-cde2-11eb-9492-af9fe4dd1731.png)

