### PR TITLE
BACKLOG-16138: Fix for when sitemap is not turned on handle 99% cases.

### DIFF
--- a/src/main/java/org/jahia/modules/sitesettingsseo/SeoUrlFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettingsseo/SeoUrlFilter.java
@@ -183,7 +183,8 @@ public class SeoUrlFilter extends AbstractFilter {
     }
 
     private String buildHref(JCRNodeWrapper node, RenderContext renderContext, String path) throws URISyntaxException, RepositoryException {
-        String serverName = Utils.getServerName(renderContext.getSite().getPropertyAsString("sitemapIndexURL"));
+        String defaultServerName = renderContext.getURLGenerator().getServer();
+        String serverName = Utils.getServerName(renderContext.getSite().getPropertyAsString("sitemapIndexURL"), defaultServerName);
         String url = rewriteUrl(path, renderContext.getRequest(), renderContext.getResponse());
         return serverName + url;
     }

--- a/src/main/java/org/jahia/modules/sitesettingsseo/utils/Utils.java
+++ b/src/main/java/org/jahia/modules/sitesettingsseo/utils/Utils.java
@@ -42,12 +42,14 @@ public class Utils {
      * General utility method to get the server-name based on url
      * In the-case it cannot be parsed to URL or it does not have protocol will return null
      *
-     * @param urlString [String] url string
+     * @param urlString         [String] url string
+     * @param defaultServerName [String] default server name
      * @return  servername in format of protocal://hostname:port
      * @throws URISyntaxException
      */
-    public static String getServerName(String urlString) throws URISyntaxException {
-        URI url = new URI(urlString);
+    public static String getServerName(String urlString, String defaultServerName) throws URISyntaxException {
+        String urlParseString = (urlString == null || urlString.isEmpty()) ? defaultServerName : urlString;
+        URI url = new URI(urlParseString);
         String protocol = url.getScheme();
         String host = url.getHost();
         int port = url.getPort();


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16138

## Description

Add-in a default value for the site-settings-seo on the server-name as the value of sitemapIndexUrl might not be available.