### PR TITLE
BACKLOG-16245: Add nodetype jnt:file to vanity URL ... action on content-editor

### DIFF
--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -31,7 +31,7 @@ export default function () {
             registry.add('action', 'vanityUrls', VanityAction, {
                 targets: ['content-editor/header/3dots:3'],
                 requiredPermission: 'siteAdminUrlmapping',
-                showOnNodeTypes: ['jmix:vanityUrlMapped', 'jnt:page', 'jmix:mainResource'],
+                showOnNodeTypes: ['jmix:vanityUrlMapped', 'jnt:page', 'jnt:file', 'jmix:mainResource'],
                 label:'site-settings-seo:label.manage',
                 dataSelRole: 'vanityUrls'
             });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16245

## Description

Trivial change to include node type jnt:file as part of the ... content-editor action