### PR TITLE
QA-13887 - Remove spaces from URL when editing

### DIFF
--- a/src/javascript/components/AddVanityUrl.jsx
+++ b/src/javascript/components/AddVanityUrl.jsx
@@ -23,6 +23,7 @@ import * as _ from 'lodash';
 import SiteSettingsSeoConstants from './SiteSettingsSeoApp.constants';
 import {flowRight as compose} from 'lodash';
 import {Add, Button} from '@jahia/moonstone';
+import {trimUrl} from './utils';
 
 const styles = theme => ({
     pickerRoot: {
@@ -299,7 +300,7 @@ class AddVanityUrl extends React.Component {
                                                 </IconButton> : null}
                                                 onFocus={() => this.handleFieldChange('focus', index, true)}
                                                 onBlur={() => this.handleFieldChange('focus', index, false)}
-                                                onChange={event => this.handleFieldChange('url', index, event.target.value)}
+                                                onChange={event => this.handleFieldChange('url', index, trimUrl(event.target.value))}
                                             />
                                             {errorForRow && <FormHelperText>
                                                 <error><label>{errorForRow.label}</label>

--- a/src/javascript/components/Editable.jsx
+++ b/src/javascript/components/Editable.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {FormControl, FormHelperText, IconButton, withStyles, Input} from '@material-ui/core';
 import {Check, Clear} from '@material-ui/icons';
+import {trimUrl} from './utils';
 
 let styles = theme => ({
     root: {
@@ -103,7 +104,7 @@ class Editable extends React.Component {
     }
 
     onValueChange(event) {
-        this.setState({value: event.target.value, errorLabel: null, errorMessage: null});
+        this.setState({value: trimUrl(event.target.value), errorLabel: null, errorMessage: null});
     }
 
     render() {

--- a/src/javascript/components/utils.js
+++ b/src/javascript/components/utils.js
@@ -7,3 +7,7 @@ export const gqlContentNodeToVanityUrlPairs = (gqlContentNode, vanityUrlsFieldNa
     urlPairs = sortBy(urlPairs, urlPair => (urlPair.default ? urlPair.default.language : urlPair.live.language));
     return values(urlPairs);
 };
+
+export const trimUrl = (url) => {
+    return url.replace(/\s/g, '')
+};


### PR DESCRIPTION
This creates a function that automatically removes unsupported characters when a vanity URL is created/modified.

For now it only removes spaces, but trimUrl can easily be updated to remove more.
