### PR TITLE
Refined the implementation based on initial request

### DIFF
--- a/src/javascript/components/utils.js
+++ b/src/javascript/components/utils.js
@@ -9,5 +9,5 @@ export const gqlContentNodeToVanityUrlPairs = (gqlContentNode, vanityUrlsFieldNa
 };
 
 export const trimUrl = (url) => {
-    return url.replace(/\s/g, '')
+    return url.trim();
 };


### PR DESCRIPTION
Since the issue raised in QA-13887 was only for spaces at the end of the URL, changed the implementation to still allow for spaces in the URL.
