### PR TITLE
BACKLOG-20592: Fix typo in vanity urls publish button.

### DIFF
--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -4,7 +4,7 @@
       "delete": "Supprimer",
       "move": "Réaffecter",
       "publish": "Publier",
-      "publishVanityUrl": "Publier les URL personnalisées",
+      "publishVanityUrl": "Publier les URLs personnalisées",
       "canonical": {
         "set": "URL canonique (URL par défaut)",
         "unset": "Ne pas définir comme canonique (URL par défault)"


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-20592