### PR TITLE
BACKLOG-20708 : add missing transitive library (redux) + set version …

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -45,7 +45,8 @@
     "react": "^16.8.4",
     "react-apollo": "^3.1.5",
     "react-dom": "^16.8.4",
-    "react-i18next": "^11.2.7"
+    "react-i18next": "^11.2.7",
+    "react-redux": "^7.2.0"
   },
   "resolutions": {
     "graphql": "15.4.0",

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,10 +29,10 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>site-settings-seo-parent</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>site-settings-seo</artifactId>
-    <version>3.7.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Site Settings - SEO Project</name>
     <description>This is the custom module (Site Settings - SEO) for running on a Digital Experience Manager server.</description>
@@ -41,7 +41,7 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>all</jahia-deploy-on-site>
         <yarn.arguments>build:simple</yarn.arguments>
-        <jahia-module-signature>MCwCFGCZtWMfzS48VB8aoAj2LvmV+DLeAhQWa1lG+xQJb5Hvh0ucEkzg0T4vQg==</jahia-module-signature>
+        <jahia-module-signature>MCwCFE3DcKiKrgkyKpiAFluO8IAcRVKsAhQDaG4kuSoYp1ybFDFk7yurz9ap4Q==</jahia-module-signature>
     </properties>
     <repositories>
         <repository>

--- a/core/webpack.shared.js
+++ b/core/webpack.shared.js
@@ -12,6 +12,7 @@ const sharedDeps = [
     'graphql-tag',
     'react-apollo',
     'redux',
+    'react-redux',
     'rxjs',
     'whatwg-fetch',
     'dayjs',

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>site-settings-seo-parent</artifactId>
     <name>Site Settings - SEO Parent Project</name>
-    <version>3.7.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Site settings seo parent</description>
 

--- a/test-module/pom.xml
+++ b/test-module/pom.xml
@@ -49,12 +49,12 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>site-settings-seo-parent</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jahia.test</groupId>
     <artifactId>site-settings-seo-test-module</artifactId>
     <name>Test module for site settings seo</name>
-    <version>3.7.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom profile module (templateSiteSettingsSEO) for running on a Jahia server.</description>
 


### PR DESCRIPTION
as the module is using jahia@ui-extender that is using redux, we need to add it as an explicit dependency 