### PR TITLE
Fixed broken nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: site-settings-seo
+          jahia_image: ${{ matrix.jahia_image }}
           testrail_project: Site Settings SEO Module
           tests_manifest: provisioning-manifest-snapshot.yml
           should_use_build_artifacts: false


### PR DESCRIPTION
The `jahia_image` parameter was missing, the workflow was using jahia/jahia-discovery-dev:8-SNAPSHOT instead of the values defined in the matrix.

Triggered nightly manually to verify the change: https://github.com/Jahia/site-settings-seo/actions/runs/4383025447