### PR TITLE
BACKLOG-20791: Add missing scm properties in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,14 @@
         <yarn.arguments>build:simple</yarn.arguments>
         <jahia-module-signature>MCwCFEkpRbsFYbi/oyt201bmG5Xx8w7vAhRlLd6nMd/25vJiPWsY/D2AxfFb6w==</jahia-module-signature>
     </properties>
+
+    <scm>
+        <connection>scm:git:git@github.com:Jahia/site-settings-seo.git</connection>
+        <developerConnection>scm:git:git@github.com:Jahia/site-settings-seo.git</developerConnection>
+        <url>scm:git:git@github.com:Jahia/site-settings-seo.git</url>
+      <tag>HEAD</tag>
+    </scm>
+
     <repositories>
         <repository>
             <releases>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20791

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


When trying to release, we get the ff. error ([link](https://github.com/Jahia/site-settings-seo/actions/runs/5215758358/jobs/9413700454#step:5:2246)):

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3-jahia1:prepare (default-cli) on project site-settings-seo: Unable to commit files
Error:  Provider message:
Error:  The git-push command failed.
Error:  Command output:
Error: [ERROR] fatal: remote error: 
Error:   Jahia/jahia-private.git/jahia-modules/site-settings-seo is not a valid repository name
```

I'm assuming this is due to missing scm properties in pom.xml which was taken out from this PR #140 
