### PR TITLE
BACKLOG-20402: Refactor CE module federation import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,17 @@
         <version>8.1.0.0</version>
     </parent>
     <artifactId>site-settings-seo</artifactId>
-    <version>4.3.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Site Settings - SEO Project</name>
     <description>This is the custom module (Site Settings - SEO) for running on a Digital Experience Manager server.</description>
     <properties>
         <jahia.plugin.version>6.6</jahia.plugin.version>
-        <jahia-depends>graphql-dxm-provider, jcontent, seo,app-shell=2.6</jahia-depends>
+        <jahia-depends>graphql-dxm-provider, jcontent=3, seo,app-shell=2.6</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>all</jahia-deploy-on-site>
         <yarn.arguments>build:simple</yarn.arguments>
-        <jahia-module-signature>MCwCFFs3MhHgAM7LZYosPx6/LMy7jca7AhR7YViZF4CDqwEjIRlZU5Wbsc4LqA==</jahia-module-signature>
+        <jahia-module-signature>MCwCFA92U494hs6aR505F3JZCI/FZsb3AhRhrWN2TicOgC5qtWwgGv38ObWMIA==</jahia-module-signature>
         <sonar.sources>src/javascript,src/main/resources/javascript</sonar.sources>
     </properties>
 
@@ -125,7 +125,7 @@
                         <configuration>
                             <arguments>sync-pom</arguments>
                         </configuration>
-                    </execution> 
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -143,7 +143,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin> 
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>

--- a/src/javascript/components/Toolbar/Toolbar.jsx
+++ b/src/javascript/components/Toolbar/Toolbar.jsx
@@ -8,7 +8,7 @@ import clsx from 'clsx';
 import {DisplayActions} from '@jahia/ui-extender';
 
 let ButtonRenderer;
-import('@jahia/content-editor').then(v => {
+import('@jahia/jcontent').then(v => {
     ButtonRenderer = v.ButtonRenderer;
 }).catch(e => console.warn('Error loading ButtonRenderer from content-editor', e));
 import {ButtonRenderer as LocalButtonRenderer} from '../Renderer/getButtonRenderer';

--- a/src/javascript/components/VanityList/DefaultRow.jsx
+++ b/src/javascript/components/VanityList/DefaultRow.jsx
@@ -8,7 +8,7 @@ import {LanguageMenu} from '../LanguageMenu';
 import {DisplayAction} from '@jahia/ui-extender';
 
 let ButtonRendererNoLabel;
-import('@jahia/content-editor').then(v => {
+import('@jahia/jcontent').then(v => {
     ButtonRendererNoLabel = v.ButtonRendererNoLabel;
 }).catch(e => console.warn('Error loading ButtonRenderer from content-editor', e));
 import {ButtonRendererNoLabel as LocalButtonRendererNoLabel} from '../Renderer/getButtonRenderer';

--- a/src/javascript/components/VanityUrlEnabledContent.jsx
+++ b/src/javascript/components/VanityUrlEnabledContent.jsx
@@ -10,7 +10,7 @@ import AddVanityUrl from './AddVanityUrl';
 import SiteSettingsSeoConstants from './SiteSettingsSeoApp.constants';
 import {DisplayAction} from '@jahia/ui-extender';
 let ButtonRenderer;
-import('@jahia/content-editor').then(v => {
+import('@jahia/jcontent').then(v => {
     ButtonRenderer = v.ButtonRenderer;
 }).catch(e => console.warn('Error loading ButtonRenderer from content-editor', e));
 import {ButtonRenderer as LocalButtonRenderer} from './Renderer/getButtonRenderer';

--- a/src/javascript/components/actions/VanityAction.jsx
+++ b/src/javascript/components/actions/VanityAction.jsx
@@ -5,7 +5,7 @@ import {SiteSettingsSeoCardEntry} from '../contentEditor/SiteSettingsSeo/SiteSet
 import * as PropTypes from 'prop-types';
 
 let useContentEditorContext;
-import('@jahia/content-editor').then(v => {
+import('@jahia/jcontent').then(v => {
     useContentEditorContext = v.useContentEditorContext;
 }).catch(e => console.warn('Error loading context from content-editor', e));
 

--- a/src/javascript/components/contentEditor/EditvanityUrlsDialog/EditVanityUrlsDialog.jsx
+++ b/src/javascript/components/contentEditor/EditvanityUrlsDialog/EditVanityUrlsDialog.jsx
@@ -8,7 +8,7 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {useVanityUrlContext} from '../../Context/VanityUrl.context';
 import {Dialog, DialogActions, DialogContent, DialogTitle} from '@material-ui/core';
 let ButtonRenderer;
-import('@jahia/content-editor').then(v => {
+import('@jahia/jcontent').then(v => {
     ButtonRenderer = v.ButtonRenderer;
 }).catch(e => console.warn('Error loading ButtonRenderer from content-editor', e));
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,7 +120,7 @@ module.exports = (env, argv) => {
                 },
                 remotes: {
                     '@jahia/app-shell': 'appShellRemote',
-                    '@jahia/content-editor': 'appShell.remotes.contentEditor'
+                    '@jahia/jcontent': 'appShell.remotes.jcontent'
                 },
                 shared
             }),

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -49,7 +49,8 @@ const singletonDeps = [
 
 const notImported = [
     '@jahia/react-material',
-    '@jahia/moonstone'
+    '@jahia/moonstone',
+    '@jahia/data-helper'
 ];
 
 const shared = sharedDeps.filter(item => deps[item]).reduce((acc, item) => ({


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20402

Update @jahia/content-editor imports to jcontent due to jcontent/CE merge and bump up version.

Moved @jahia/data-helper to `notImported` in webpack config to resolve conflict with jcontent. Will create a follow-up story to fully migrate webpack config using `@jahia/webpack-config` module.