### PR TITLE
BACKLOG-20402: Add required modules in provisioning

### DIFF
--- a/tests/cypress/e2e/copyCutPaste.cy.ts
+++ b/tests/cypress/e2e/copyCutPaste.cy.ts
@@ -3,6 +3,7 @@ import { addVanityUrl, removeVanityUrl, getVanityUrl, deleteNode, moveNode } fro
 
 describe('Copy Cut and Paste tests with Vanity Urls', () => {
     before('Set vanityUrl', () => {
+        cy.apollo({ mutationFile: 'graphql/enableLegacyPageComposer.graphql' })
         cy.login()
         addVanityUrl('/sites/digitall/home/about', 'en', '/about')
         cy.logout()

--- a/tests/cypress/e2e/edit/addVanityUrlUi.cy.ts
+++ b/tests/cypress/e2e/edit/addVanityUrlUi.cy.ts
@@ -10,6 +10,10 @@ describe('Add vanity Urls', () => {
     const pageVanityUrl1 = 'page1'
     const pageVanityUrl2 = 'page2'
 
+    before('init', function () {
+        cy.apollo({ mutationFile: 'graphql/enableLegacyPageComposer.graphql' })
+    })
+
     beforeEach('create test data', function () {
         addSimplePage(homePath, pageVanityUrl1, pageVanityUrl1, 'en')
         setNodeProperty(homePath + '/' + pageVanityUrl1, 'jcr:title', pageVanityUrl1 + '-fr', 'fr')

--- a/tests/cypress/e2e/edit/editVanityUrlUi.cy.ts
+++ b/tests/cypress/e2e/edit/editVanityUrlUi.cy.ts
@@ -1,4 +1,4 @@
-import { publishAndWaitJobEnding, deleteNode, addVanityUrl, setNodeProperty, addNode } from '@jahia/cypress'
+import { publishAndWaitJobEnding, deleteNode, addVanityUrl, setNodeProperty } from '@jahia/cypress'
 import { addSimplePage, checkVanityUrlByAPI, checkVanityUrlDoNotExistByAPI } from '../../utils/Utils'
 import { CustomPageComposer } from '../../page-object/pageComposer/CustomPageComposer'
 describe('Edit vanity Urls', () => {
@@ -9,6 +9,10 @@ describe('Edit vanity Urls', () => {
     const pageVanityUrl2 = 'page2'
     const pageVanityUrl1Path = homePath + '/' + pageVanityUrl2
     const pageVanityUrl2Path = homePath + '/' + pageVanityUrl2
+
+    before('init', function () {
+        cy.apollo({ mutationFile: 'graphql/enableLegacyPageComposer.graphql' })
+    })
 
     beforeEach('create test data', function () {
         addSimplePage(homePath, pageVanityUrl1, pageVanityUrl1, 'en')

--- a/tests/cypress/fixtures/graphql/enableLegacyPageComposer.graphql
+++ b/tests/cypress/fixtures/graphql/enableLegacyPageComposer.graphql
@@ -1,0 +1,9 @@
+mutation {
+    admin {
+        jahia {
+            configuration(pid:"org.jahia.modules.jcontent") {
+                value(name:"hideLegacyPageComposer", value:"false")
+            }
+        }
+    }
+}

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,7 +1,15 @@
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
 - addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
   username: ${env:NEXUS_USERNAME}
   password: ${env:NEXUS_PASSWORD}
+
+- uninstallBundle:
+    - 'mvn:org.jahia.modules/content-editor/3.6.0'
+
 - installBundle:
+    - 'mvn:org.jahia.modules/jcontent'
+    - 'mvn:org.jahia.modules/event'
+    - 'mvn:org.jahia.modules/site-settings-seo'
     - 'mvn:org.jahia.modules/press/3.0.0'
     - 'mvn:org.jahia.modules/person/3.1.0'
     - 'mvn:org.jahia.modules/news/3.4.0'
@@ -12,13 +20,11 @@
     - 'mvn:org.jahia.modules/location/3.0.0'
     - 'mvn:org.jahia.modules/topstories/3.0.0'
     - 'mvn:org.jahia.modules/rating/3.2.0'
-    - 'mvn:org.jahia.modules/event/3.0.0'
     - 'mvn:org.jahia.modules/bookmarks/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-core/2.2.0'
     - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-components/2.1.0'
     - 'mvn:org.jahia.modules/digitall/2.0.0'
-    - 'mvn:org.jahia.modules/content-editor/4.5.0'
   autoStart: true
   uninstallPreviousVersion: true
 

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,7 +1,15 @@
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
 - addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
   username: ${env:NEXUS_USERNAME}
   password: ${env:NEXUS_PASSWORD}
+
+- uninstallBundle:
+    - 'mvn:org.jahia.modules/content-editor/3.6.0'
+
 - installBundle:
+    - 'mvn:org.jahia.modules/jcontent'
+    - 'mvn:org.jahia.modules/event'
+    - 'mvn:org.jahia.modules/site-settings-seo'
     - 'mvn:org.jahia.modules/press/3.0.0'
     - 'mvn:org.jahia.modules/person/3.1.0'
     - 'mvn:org.jahia.modules/news/3.4.0'
@@ -12,14 +20,11 @@
     - 'mvn:org.jahia.modules/location/3.0.0'
     - 'mvn:org.jahia.modules/topstories/3.0.0'
     - 'mvn:org.jahia.modules/rating/3.2.0'
-    - 'mvn:org.jahia.modules/event/3.0.0'
     - 'mvn:org.jahia.modules/bookmarks/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-core/2.2.0'
     - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-components/2.1.0'
     - 'mvn:org.jahia.modules/digitall/2.0.0'
-    - 'mvn:org.jahia.modules/content-editor/4.5.0'
-    - 'mvn:org.jahia.modules/site-settings-seo'
     - 'mvn:org.jahia.test/site-settings-seo-test-module'
   autoStart: true
   uninstallPreviousVersion: true


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20402

## Description

- Modified provisioning files to include latest jcontent, event and site-settings-seo snapshots (needed to be able to resolve digital modules, import properly)
- Re-enable legacy gwt composer needed for some tests
