### PR TITLE
Set parent version to Jahia 8.2.0.0

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -35,7 +35,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -27,7 +27,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -58,7 +58,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,7 +15,7 @@ jobs:
     # downloading the entire world when building.
     # More on https://github.com/Jahia/cimg-mvn-cache
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
          supported_branches: ["${{ github.event.repository.default_branch }}"]
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in the repository.
 # Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*    @Jahia/elastic_and_scalable_yetis_dev
+*    @Jahia/team-tty

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.1.0.0</version>
+        <version>8.2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>site-settings-seo</artifactId>
     <version>5.0.0-SNAPSHOT</version>


### PR DESCRIPTION
There was already a jahia-depends on jcontent=3 (which itself is dependant upon jahia 8.2.0.0), but we should make this explicit.

Updated build image as per: https://jahia.slack.com/archives/CNXE64ATE/p1696251699430759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Chore**: 
- Updated the Docker image used in GitHub Actions workflows from `jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node` to `jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node`, transitioning from OpenJDK 8 to OpenJDK 11.
- Changed the default owners for pull request reviews from `@Jahia/elastic_and_scalable_yetis_dev` to `@Jahia/team-tty`.

**Refactor**:
- Bumped up the version of the parent artifact in the `site-settings-seo` module from `8.1.0.0` to `8.2.0.0-SNAPSHOT`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->