### PR TITLE
QA-14836: Fix inconsistency in permission checks for vanity URL access.

### DIFF
--- a/src/javascript/components/Register/registerActions.js
+++ b/src/javascript/components/Register/registerActions.js
@@ -8,7 +8,7 @@ export const registerActions = () => {
     registry.add('action', 'vanityUrls', {
         component: VanityAction,
         targets: ['content-editor/header/3dots:3'],
-        requiredPermission: 'siteAdminUrlmapping',
+        requiredPermission: 'viewVanityUrlModal',
         showOnNodeTypes: ['jmix:vanityUrlMapped', 'jnt:page', 'jnt:file', 'jmix:mainResource', 'jmix:canHaveVanityUrls'],
         label: 'site-settings-seo:label.manage',
         dataSelRole: 'vanityUrls'

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -2,4 +2,9 @@
     <site-admin jcr:primaryType="jnt:permission">
         <siteAdminUrlmapping jcr:primaryType="jnt:permission"/>
     </site-admin>
+    <jContent jcr:primaryType="jnt:permission">
+        <engineTabs jcr:primaryType="jnt:permission">
+            <viewVanityUrlModal jcr:primaryType="jnt:permission"/>
+        </engineTabs>
+    </jContent>
 </permissions>

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -4,6 +4,15 @@
        xmlns:j="http://www.jahia.org/jahia/1.0"
        xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
     <editor j:hidden="false"
+            jcr:primaryType="jnt:role"
             j:permissionNames="siteAdminUrlmapping"
-            jcr:primaryType="jnt:role"/>
+            j:privilegedAccess="true">
+        <currentSite-access j:path="currentSite"
+                            j:permissionNames="viewVanityUrlModal"
+                            jcr:primaryType="jnt:externalPermissions"/>
+        <editor-in-chief jcr:primaryType="jnt:role"
+                         j:permissionNames="siteAdminUrlmapping"
+                         j:privilegedAccess="true"
+        />
+    </editor>
 </roles>

--- a/src/main/resources/resources/site-settings-seo_de.properties
+++ b/src/main/resources/resources/site-settings-seo_de.properties
@@ -1,4 +1,5 @@
 jnt_siteSettingsSeo=SEO
 label.permission.siteAdminUrlmapping=Site admin url mapping
 label.permission.siteAdminUrlmapping.description=Ermöglicht Ihnen die Verwaltung von Vanity-URLs einer Website
+label.permission.viewVanityUrlModal.description=Bearbeiten Sie Vanity-URLs für Website
 siteSettingsSeo.title=URL-Mappings

--- a/src/main/resources/resources/site-settings-seo_en.properties
+++ b/src/main/resources/resources/site-settings-seo_en.properties
@@ -1,4 +1,5 @@
 jnt_siteSettingsSeo=SEO
 label.permission.siteAdminUrlmapping=Site admin url mapping
 label.permission.siteAdminUrlmapping.description=Allows you to manage vanity URLs of a site
+label.permission.viewVanityUrlModal.description=Edit Vanity URLs for site
 siteSettingsSeo.title=Vanity URLs

--- a/src/main/resources/resources/site-settings-seo_fr.properties
+++ b/src/main/resources/resources/site-settings-seo_fr.properties
@@ -1,4 +1,5 @@
 jnt_siteSettingsSeo=SEO
 label.permission.siteAdminUrlmapping=Site admin url mapping
 label.permission.siteAdminUrlmapping.description=Permet de gérer les mapping d'URLs d'un site
+label.permission.viewVanityUrlModal.description=Modifier les URL personnalisées pour le site
 siteSettingsSeo.title=URL personnalisées


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-14836
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Introduced a new permission, `viewVanityUrlModal`, to manage vanity URLs for a site. This change allows users with the specified permission to view and edit vanity URLs.
- Updated SEO settings page title to "Vanity URLs" to reflect the new functionality.

**Localization:**
- Added descriptions for the new permission in English, German, and French language files. This ensures that users across different regions can understand the purpose of the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->