### PR TITLE
 BACKLOG-21276 : migrate vanity URL on file test

### DIFF
--- a/tests/cypress/e2e/edit/addVanityUrlUi.cy.ts
+++ b/tests/cypress/e2e/edit/addVanityUrlUi.cy.ts
@@ -1,4 +1,4 @@
-import { publishAndWaitJobEnding, deleteNode, addVanityUrl, setNodeProperty, setNodeProperty } from '@jahia/cypress'
+import { publishAndWaitJobEnding, deleteNode, addVanityUrl, setNodeProperty } from '@jahia/cypress'
 import { CustomPageComposer } from '../../page-object/pageComposer/CustomPageComposer'
 import { addSimplePage, checkVanityUrlByAPI, checkVanityUrlDoNotExistByAPI } from '../../utils/Utils'
 import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'

--- a/tests/cypress/e2e/edit/addVanityUrlUi.cy.ts
+++ b/tests/cypress/e2e/edit/addVanityUrlUi.cy.ts
@@ -1,4 +1,4 @@
-import { publishAndWaitJobEnding, deleteNode, addVanityUrl, setNodeProperty } from '@jahia/cypress'
+import { publishAndWaitJobEnding, deleteNode, addVanityUrl, setNodeProperty, setNodeProperty } from '@jahia/cypress'
 import { CustomPageComposer } from '../../page-object/pageComposer/CustomPageComposer'
 import { addSimplePage, checkVanityUrlByAPI, checkVanityUrlDoNotExistByAPI } from '../../utils/Utils'
 import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'

--- a/tests/cypress/e2e/edit/addVanityUrlonFileUi.cy.ts
+++ b/tests/cypress/e2e/edit/addVanityUrlonFileUi.cy.ts
@@ -34,7 +34,6 @@ describe('Add or edit vanity Urls', () => {
         publishAndWaitJobEnding(sitePath + filePath + fileName)
 
         cy.request(Cypress.env('JAHIA_URL') + '/vanityFile1').then((response) => {
-            // expect(response.body).to.have.length(500)
             const mime = response.headers['content-type']
             expect(mime).to.contains('image/jpeg')
             const length = response.headers['content-length']

--- a/tests/cypress/e2e/edit/addVanityUrlonFileUi.cy.ts
+++ b/tests/cypress/e2e/edit/addVanityUrlonFileUi.cy.ts
@@ -1,0 +1,44 @@
+import { publishAndWaitJobEnding, editSite } from '@jahia/cypress'
+import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'
+
+import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
+
+describe('Add or edit vanity Urls', () => {
+    const siteKey = 'digitall'
+    const sitePath = '/sites/' + siteKey
+    const fileName = 'foods.jpg'
+    const filePath = '/files/images/backgrounds/'
+    const jcontentFilePath = 'media' + filePath
+
+    before('set server test data', function () {
+        editSite('digitall', { serverName: 'jahia' })
+    })
+
+    after('clear server test data', function () {
+        editSite('digitall', { serverName: 'localhost' })
+    })
+
+    it('Add a first basic vanity URL on a file', function () {
+        cy.login()
+
+        JContent.visit('digitall', 'en', jcontentFilePath)
+
+        new JContent().switchToListMode()
+        new JContent().editComponentByText(fileName)
+
+        const contentEditor = new ContentEditorSEO()
+
+        const vanityUrlUi = contentEditor.openVanityUrlUi()
+        vanityUrlUi.addVanityUrl('vanityFile1', true)
+
+        publishAndWaitJobEnding(sitePath + filePath + fileName)
+
+        cy.request(Cypress.env('JAHIA_URL') + '/vanityFile1').then((response) => {
+            // expect(response.body).to.have.length(500)
+            const mime = response.headers['content-type']
+            expect(mime).to.contains('image/jpeg')
+            const length = response.headers['content-length']
+            expect(length).to.eq('83342')
+        })
+    })
+})

--- a/tests/cypress/e2e/edit/addVanityUrlonFileUi.cy.ts
+++ b/tests/cypress/e2e/edit/addVanityUrlonFileUi.cy.ts
@@ -3,7 +3,7 @@ import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'
 
 import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
 
-describe('Add or edit vanity Urls', () => {
+describe('Add or edit vanity Urls on a file', () => {
     const siteKey = 'digitall'
     const sitePath = '/sites/' + siteKey
     const fileName = 'foods.jpg'
@@ -23,6 +23,13 @@ describe('Add or edit vanity Urls', () => {
 
         JContent.visit('digitall', 'en', jcontentFilePath)
 
+        // vanity url is not created yet, a direct access should triggers a 404 error
+        cy.request({ method: 'GET', url: Cypress.env('JAHIA_URL') + '/vanityFile1', failOnStatusCode: false }).then(
+            (response) => {
+                expect(response.status).to.eq(404)
+            },
+        )
+
         new JContent().switchToListMode()
         new JContent().editComponentByText(fileName)
 
@@ -33,7 +40,9 @@ describe('Add or edit vanity Urls', () => {
 
         publishAndWaitJobEnding(sitePath + filePath + fileName)
 
+        // vanity url is created yet, a direct access allows to download the file
         cy.request(Cypress.env('JAHIA_URL') + '/vanityFile1').then((response) => {
+            expect(response.status).to.eq(200)
             const mime = response.headers['content-type']
             expect(mime).to.contains('image/jpeg')
             const length = response.headers['content-length']


### PR DESCRIPTION








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new end-to-end test case "Add a first basic vanity URL on a file". This test case covers the functionality of adding a vanity URL to a file, publishing the changes, and verifying the response status and content type of the vanity URL. This will help ensure the robustness and reliability of the vanity URL feature in the application.
- Chore: Updated import statements in test files for better modularity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->