### PR TITLE
BACKLOG-21642 : add test remove vanity url on a file

### DIFF
--- a/tests/cypress/e2e/edit/removeVanityUrlonFileUi.cy.ts
+++ b/tests/cypress/e2e/edit/removeVanityUrlonFileUi.cy.ts
@@ -1,0 +1,56 @@
+import {publishAndWaitJobEnding, editSite, addVanityUrl} from '@jahia/cypress'
+import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'
+
+import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
+
+describe('Add or edit vanity Urls on a file', () => {
+    const siteKey = 'digitall'
+    const sitePath = '/sites/' + siteKey
+    const fileName = 'foods.jpg'
+    const filePath = '/files/images/backgrounds/'
+    const jcontentFilePath = 'media' + filePath
+
+    before('set server test data', function () {
+        editSite('digitall', { serverName: 'jahia' })
+        addVanityUrl(sitePath + filePath + fileName, 'en', '/vanityFileToRemove')
+        publishAndWaitJobEnding(sitePath + filePath + fileName)
+    })
+
+    after('clear server test data', function () {
+        editSite('digitall', { serverName: 'localhost' })
+    })
+
+    it('Add a first basic vanity URL on a file', function () {
+
+        // vanity url is created, a direct access allows to download the file
+        cy.request(Cypress.env('JAHIA_URL') + '/vanityFileToRemove').then((response) => {
+            expect(response.status).to.eq(200)
+            const mime = response.headers['content-type']
+            expect(mime).to.contains('image/jpeg')
+            const length = response.headers['content-length']
+            expect(length).to.eq('83342')
+        })
+
+        cy.login()
+
+        JContent.visit('digitall', 'en', jcontentFilePath)
+
+        new JContent().switchToListMode()
+        new JContent().editComponentByText(fileName)
+
+        const contentEditor = new ContentEditorSEO()
+
+        const vanityUrlUi = contentEditor.openVanityUrlUi()
+        vanityUrlUi.deleteVanityUrl('/vanityFileToRemove')
+
+        publishAndWaitJobEnding(sitePath + filePath + fileName)
+
+        // vanity url is deleted, a direct access should triggers a 404 error
+        cy.request({ method: 'GET', url: Cypress.env('JAHIA_URL') + '/vanityFileToRemove', failOnStatusCode: false }).then(
+            (response) => {
+                expect(response.status).to.eq(404)
+            },
+        )
+
+    })
+})

--- a/tests/cypress/e2e/edit/removeVanityUrlonFileUi.cy.ts
+++ b/tests/cypress/e2e/edit/removeVanityUrlonFileUi.cy.ts
@@ -1,9 +1,8 @@
-import {publishAndWaitJobEnding, editSite, addVanityUrl} from '@jahia/cypress'
+import { publishAndWaitJobEnding, editSite, addVanityUrl } from '@jahia/cypress'
 import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'
-
 import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
 
-describe('Add or edit vanity Urls on a file', () => {
+describe('Remove vanity Urls from a file', () => {
     const siteKey = 'digitall'
     const sitePath = '/sites/' + siteKey
     const fileName = 'foods.jpg'
@@ -21,7 +20,6 @@ describe('Add or edit vanity Urls on a file', () => {
     })
 
     it('Add a first basic vanity URL on a file', function () {
-
         // vanity url is created, a direct access allows to download the file
         cy.request(Cypress.env('JAHIA_URL') + '/vanityFileToRemove').then((response) => {
             expect(response.status).to.eq(200)
@@ -46,11 +44,21 @@ describe('Add or edit vanity Urls on a file', () => {
         publishAndWaitJobEnding(sitePath + filePath + fileName)
 
         // vanity url is deleted, a direct access should triggers a 404 error
-        cy.request({ method: 'GET', url: Cypress.env('JAHIA_URL') + '/vanityFileToRemove', failOnStatusCode: false }).then(
-            (response) => {
-                expect(response.status).to.eq(404)
-            },
-        )
+        cy.request({
+            method: 'GET',
+            url: Cypress.env('JAHIA_URL') + '/vanityFileToRemove',
+            failOnStatusCode: false,
+        }).then((response) => {
+            expect(response.status).to.eq(404)
+        })
 
+        // Check direct access to the file's url still works
+        cy.request(Cypress.env('JAHIA_URL') + '/files/live' + sitePath + filePath + fileName).then((response) => {
+            expect(response.status).to.eq(200)
+            const mime = response.headers['content-type']
+            expect(mime).to.contains('image/jpeg')
+            const length = response.headers['content-length']
+            expect(length).to.eq('83342')
+        })
     })
 })


### PR DESCRIPTION






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Test: Introduced a new test case to ensure the proper functioning of the vanity URL removal feature. This test checks that after a vanity URL is deleted from a file, it no longer exists and accessing it returns a 404 error. This helps to maintain the integrity of our file management system and ensures that users are directed to the correct resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->