### PR TITLE
QA-14836 : add cypress test

### DIFF
--- a/tests/cypress/e2e/permissions/checkVanityUrlModalPermissions.cy.ts
+++ b/tests/cypress/e2e/permissions/checkVanityUrlModalPermissions.cy.ts
@@ -1,0 +1,165 @@
+import {
+    publishAndWaitJobEnding,
+    createSite,
+    deleteSite,
+    createUser,
+    deleteUser,
+    grantRoles,
+    addNode,
+    deleteNode,
+} from '@jahia/cypress'
+import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
+import { ContentEditorSEO } from '../../page-object/ContentEditorSEO'
+import { checkVanityUrlByAPI } from '../../utils/Utils'
+
+describe('Test UIs permissions', () => {
+    const siteKey = 'siteForPermissionsCheck'
+    const sitePath = '/sites/' + siteKey
+    const homePath = sitePath + '/home'
+    const pageNameA = 'basic-pageA'
+    const pageNameB = 'basic-pageB'
+    const pagePathA = homePath + '/' + pageNameA
+    const pagePathB = homePath + '/' + pageNameB
+    const langEN = 'en'
+    const siteConfig = {
+        languages: langEN,
+        templateSet: 'dx-base-demo-templates',
+        serverName: 'localhost',
+        locale: langEN,
+    }
+
+    const createPage = (parent: string, name: string, template: string, lang: string) => {
+        cy.apollo({
+            variables: {
+                parentPathOrId: parent,
+                name: name,
+                template: template,
+                language: lang,
+            },
+            mutationFile: 'graphql/jcrAddPage.graphql',
+        })
+    }
+
+    before('Create test data', function () {
+        // Create a new website with 2 pages
+        createSite(siteKey, siteConfig)
+        createPage(homePath, pageNameA, 'simple', langEN)
+        createPage(homePath, pageNameB, 'simple', langEN)
+        publishAndWaitJobEnding(homePath)
+
+        // Create 2 new role `: one with vanity url modal access, one without vanity url modal access
+        addNode({
+            parentPathOrId: '/roles',
+            name: 'vanityRole',
+            primaryNodeType: 'jnt:role',
+            properties: [
+                {
+                    name: 'j:permissionNames',
+                    values: ['jcr:all_default', 'viewVanityUrlModal'],
+                },
+                { name: 'j:hidden', value: 'false' },
+                { name: 'j:roleGroup', value: 'edit-role' },
+                { name: 'j:privilegedAccess', value: 'true' },
+            ],
+        })
+        addNode({
+            parentPathOrId: '/roles/vanityRole',
+            name: 'currentSite-access',
+            primaryNodeType: 'jnt:externalPermissions',
+            properties: [
+                {
+                    name: 'j:permissionNames',
+                    values: [
+                        'viewContentTab',
+                        'jContentAccess',
+                        'jContentAccordions',
+                        'jContentActions',
+                        'pageComposerAccess',
+                        'components',
+                        'templates',
+                    ],
+                },
+                { name: 'j:path', value: 'currentSite' },
+            ],
+        })
+        addNode({
+            parentPathOrId: '/roles',
+            name: 'noVanityRole',
+            primaryNodeType: 'jnt:role',
+            properties: [
+                {
+                    name: 'j:permissionNames',
+                    values: ['jcr:all_default'],
+                },
+                { name: 'j:hidden', value: 'false' },
+                { name: 'j:roleGroup', value: 'edit-role' },
+                { name: 'j:privilegedAccess', value: 'true' },
+            ],
+        })
+        addNode({
+            parentPathOrId: '/roles/noVanityRole',
+            name: 'currentSite-access',
+            primaryNodeType: 'jnt:externalPermissions',
+            properties: [
+                {
+                    name: 'j:permissionNames',
+                    values: [
+                        'viewContentTab',
+                        'jContentAccess',
+                        'jContentAccordions',
+                        'jContentActions',
+                        'pageComposerAccess',
+                        'components',
+                        'templates',
+                    ],
+                },
+                { name: 'j:path', value: 'currentSite' },
+            ],
+        })
+
+        // Create a user and grant him the vanityUrl role on pageA and noVanityUrl role on pageB
+        createUser('user1', 'password')
+        grantRoles(pagePathA, ['vanityRole'], 'user1', 'USER')
+        grantRoles(pagePathB, ['noVanityRole'], 'user1', 'USER')
+    })
+
+    after('Clear test data', function () {
+        deleteSite(siteKey)
+        deleteUser('user1')
+        deleteNode('/roles/vanityRole')
+        deleteNode('/roles/noVanityRole')
+    })
+
+    it('Verify that user having permission can see and edit some data in the vanity url modal', function () {
+        cy.login('user1', 'password')
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
+        jcontent.switchToListMode()
+        jcontent.editComponentByText(pageNameA)
+        const contenteditor = new ContentEditorSEO()
+        contenteditor.checkVanityUrlAccess(false)
+        const vanityUrlUi = contenteditor.openVanityUrlUi()
+        vanityUrlUi.addVanityUrl('vanityurl-test-modalAccess')
+
+        // Check vanity url was created as expected
+        checkVanityUrlByAPI(
+            pagePathA + '/vanityUrlMapping/vanityurl-test-modalAccess',
+            'vanityurl-test-modalAccess',
+            'fr',
+            'EDIT',
+            'false',
+        )
+
+        cy.logout()
+    })
+
+    it('Verify that user without permission cannot see the vanity url modal', function () {
+        cy.login('user1', 'password')
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
+        jcontent.switchToListMode()
+        jcontent.editComponentByText(pageNameB)
+        const contenteditor = new ContentEditorSEO()
+        contenteditor.checkVanityUrlAccess(false)
+
+        cy.logout()
+    })
+})

--- a/tests/cypress/e2e/permissions/checkViewVanityUrlModalPermissions.cy.ts
+++ b/tests/cypress/e2e/permissions/checkViewVanityUrlModalPermissions.cy.ts
@@ -61,27 +61,29 @@ describe('Test UIs permissions', () => {
                 { name: 'j:roleGroup', value: 'edit-role' },
                 { name: 'j:privilegedAccess', value: 'true' },
             ],
-        })
-        addNode({
-            parentPathOrId: '/roles/vanityRole',
-            name: 'currentSite-access',
-            primaryNodeType: 'jnt:externalPermissions',
-            properties: [
+            children: [
                 {
-                    name: 'j:permissionNames',
-                    values: [
-                        'viewContentTab',
-                        'jContentAccess',
-                        'jContentAccordions',
-                        'jContentActions',
-                        'pageComposerAccess',
-                        'components',
-                        'templates',
+                    name: 'currentSite-access',
+                    primaryNodeType: 'jnt:externalPermissions',
+                    properties: [
+                        {
+                            name: 'j:permissionNames',
+                            values: [
+                                'viewContentTab',
+                                'jContentAccess',
+                                'jContentAccordions',
+                                'jContentActions',
+                                'pageComposerAccess',
+                                'components',
+                                'templates',
+                            ],
+                        },
+                        { name: 'j:path', value: 'currentSite' },
                     ],
                 },
-                { name: 'j:path', value: 'currentSite' },
             ],
         })
+
         addNode({
             parentPathOrId: '/roles',
             name: 'noVanityRole',
@@ -95,25 +97,26 @@ describe('Test UIs permissions', () => {
                 { name: 'j:roleGroup', value: 'edit-role' },
                 { name: 'j:privilegedAccess', value: 'true' },
             ],
-        })
-        addNode({
-            parentPathOrId: '/roles/noVanityRole',
-            name: 'currentSite-access',
-            primaryNodeType: 'jnt:externalPermissions',
-            properties: [
+            children: [
                 {
-                    name: 'j:permissionNames',
-                    values: [
-                        'viewContentTab',
-                        'jContentAccess',
-                        'jContentAccordions',
-                        'jContentActions',
-                        'pageComposerAccess',
-                        'components',
-                        'templates',
+                    name: 'currentSite-access',
+                    primaryNodeType: 'jnt:externalPermissions',
+                    properties: [
+                        {
+                            name: 'j:permissionNames',
+                            values: [
+                                'viewContentTab',
+                                'jContentAccess',
+                                'jContentAccordions',
+                                'jContentActions',
+                                'pageComposerAccess',
+                                'components',
+                                'templates',
+                            ],
+                        },
+                        { name: 'j:path', value: 'currentSite' },
                     ],
                 },
-                { name: 'j:path', value: 'currentSite' },
             ],
         })
 
@@ -130,16 +133,25 @@ describe('Test UIs permissions', () => {
         deleteNode('/roles/noVanityRole')
     })
 
+    it('Verify that user having permission can see the vanity url modal button', function () {
+        cy.login('user1', 'password')
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
+        jcontent.switchToListMode()
+        jcontent.editComponentByText(pageNameA)
+        const contenteditor = new ContentEditorSEO()
+        contenteditor.checkVanityUrlVisibility(true)
+
+        cy.logout()
+    })
+
     it('Verify that user having permission can see and edit some data in the vanity url modal', function () {
         cy.login('user1', 'password')
         const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
         jcontent.switchToListMode()
         jcontent.editComponentByText(pageNameA)
         const contenteditor = new ContentEditorSEO()
-        contenteditor.checkVanityUrlAccess(false)
         const vanityUrlUi = contenteditor.openVanityUrlUi()
         vanityUrlUi.addVanityUrl('vanityurl-test-modalAccess')
-
         // Check vanity url was created as expected
         checkVanityUrlByAPI(
             pagePathA + '/vanityUrlMapping/vanityurl-test-modalAccess',
@@ -148,6 +160,7 @@ describe('Test UIs permissions', () => {
             'EDIT',
             'false',
         )
+        vanityUrlUi.getVanityUrlRow('/vanityurl-test-modalAccess')
 
         cy.logout()
     })
@@ -158,7 +171,7 @@ describe('Test UIs permissions', () => {
         jcontent.switchToListMode()
         jcontent.editComponentByText(pageNameB)
         const contenteditor = new ContentEditorSEO()
-        contenteditor.checkVanityUrlAccess(false)
+        contenteditor.checkVanityUrlVisibility(false)
 
         cy.logout()
     })

--- a/tests/cypress/page-object/ContentEditorSEO.ts
+++ b/tests/cypress/page-object/ContentEditorSEO.ts
@@ -16,4 +16,13 @@ export class ContentEditorSEO extends ContentEditor {
         cy.get('button[data-sel-role="3dotsMenuAction"]').click()
         cy.get('li[data-sel-role="vanityUrls"]').should('have.attr', 'aria-disabled', enabled)
     }
+
+    checkVanityUrlAccess(visible) {
+        cy.get('button[data-sel-role="3dotsMenuAction"]').click()
+        if ('true' == visible) {
+            cy.get('li[data-sel-role="vanityUrls"]').should('be.visible')
+        } else {
+            cy.get('li[data-sel-role="vanityUrls"]').should('not.be.visible')
+        }
+    }
 }

--- a/tests/cypress/page-object/ContentEditorSEO.ts
+++ b/tests/cypress/page-object/ContentEditorSEO.ts
@@ -17,9 +17,9 @@ export class ContentEditorSEO extends ContentEditor {
         cy.get('li[data-sel-role="vanityUrls"]').should('have.attr', 'aria-disabled', enabled)
     }
 
-    checkVanityUrlAccess(visible) {
+    checkVanityUrlAccess(isVisible) {
         cy.get('button[data-sel-role="3dotsMenuAction"]').click()
-        if ('true' == visible) {
+        if (isVisible) {
             cy.get('li[data-sel-role="vanityUrls"]').should('be.visible')
         } else {
             cy.get('li[data-sel-role="vanityUrls"]').should('not.be.visible')

--- a/tests/cypress/page-object/ContentEditorSEO.ts
+++ b/tests/cypress/page-object/ContentEditorSEO.ts
@@ -17,12 +17,8 @@ export class ContentEditorSEO extends ContentEditor {
         cy.get('li[data-sel-role="vanityUrls"]').should('have.attr', 'aria-disabled', enabled)
     }
 
-    checkVanityUrlAccess(isVisible) {
+    checkVanityUrlVisibility(isVisible) {
         cy.get('button[data-sel-role="3dotsMenuAction"]').click()
-        if (isVisible) {
-            cy.get('li[data-sel-role="vanityUrls"]').should('be.visible')
-        } else {
-            cy.get('li[data-sel-role="vanityUrls"]').should('not.be.visible')
-        }
+        cy.get('li[data-sel-role="vanityUrls"]').should(isVisible ? 'be.visible' : 'not.be.visible')
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added a new test case to verify user permissions for viewing and editing data in the vanity URL modal.
	- Introduced a function to check the visibility of the vanity URL menu item in the content editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->