### PR TITLE
BACKLOG-22208: check ref current exists before accessing to it (#191)

### DIFF
--- a/src/javascript/components/Move.jsx
+++ b/src/javascript/components/Move.jsx
@@ -122,7 +122,7 @@ const MoveCmp = props => {
 
     if (!loading && !error && data && data.jcr && data.jcr.nodeByPath.inPicker) {
         setTimeout(() => {
-            picker.current.openPaths(data.jcr.nodeByPath.path.substr(0, data.jcr.nodeByPath.path.lastIndexOf('/')));
+            picker?.current?.openPaths(data.jcr.nodeByPath.path.substr(0, data.jcr.nodeByPath.path.lastIndexOf('/')));
         });
     }
 


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22208

Check if Picker is present before setting the value of the open path on move