### PR TITLE
BACKLOG-22303: Add close behavior on toast notifications

### DIFF
--- a/src/javascript/components/AddVanityUrl.jsx
+++ b/src/javascript/components/AddVanityUrl.jsx
@@ -218,15 +218,15 @@ class AddVanityUrlComponent extends React.Component {
                 if (this.state.doPublish) {
                     vanityMutationsContext.publish(result.data.jcr.modifiedNodes.map(entry => entry.uuid)).then(result => {
                         this.handleClose(event);
-                        notificationContext.notify(t('label.notifications.newMappingCreatedAndPublished'));
+                        notificationContext.notify(t('label.notifications.newMappingCreatedAndPublished'), ['closeAfter5s']);
                     }, error => {
-                        notificationContext.notify(t('label.errors.Error'));
+                        notificationContext.notify(t('label.errors.Error'), ['closeButton', 'noAutomaticClose']);
                         console.log(error);
                     });
                 } else {
                     setParentLoading && setParentLoading(true);
                     this.handleClose(event);
-                    notificationContext.notify(t('label.notifications.newMappingCreated'));
+                    notificationContext.notify(t('label.notifications.newMappingCreated'), ['closeAfter5s']);
                 }
             }, error => {
                 if (error.graphQLErrors && error.graphQLErrors[0].extensions) {
@@ -247,7 +247,7 @@ class AddVanityUrlComponent extends React.Component {
                         })
                     });
                 } else {
-                    notificationContext.notify(t('label.errors.Error'));
+                    notificationContext.notify(t('label.errors.Error'), ['closeButton', 'noAutomaticClose']);
                     console.log(error);
                 }
             });
@@ -263,7 +263,7 @@ class AddVanityUrlComponent extends React.Component {
                     })
                 });
             } else {
-                notificationContext.notify(t('label.errors.' + (e.name ? e.name : 'Error')));
+                notificationContext.notify(t('label.errors.' + (e.name ? e.name : 'Error')), ['closeButton', 'noAutomaticClose']);
             }
         }
     };

--- a/src/javascript/components/Move.jsx
+++ b/src/javascript/components/Move.jsx
@@ -82,21 +82,21 @@ const MoveCmp = props => {
             vanityMutationsContext.move(_.map(urlPairs, 'uuid'), targetPath, props)
                 .then(() => {
                     handleClose();
-                    notificationContext.notify(t('label.notifications.moveConfirmed'));
+                    notificationContext.notify(t('label.notifications.moveConfirmed'), ['closeAfter5s']);
                 })
                 .catch(errors => {
                     if (errors.graphQLErrors) {
                         _.each(errors.graphQLErrors, error => {
-                            notificationContext.notify(error.message);
+                            notificationContext.notify(error.message, ['closeButton', 'noAutomaticClose']);
                         });
                     } else {
-                        notificationContext.notify(t('label.errors.Error'));
+                        notificationContext.notify(t('label.errors.Error'), ['closeButton', 'noAutomaticClose']);
                     }
 
                     console.log(errors);
                 });
         } catch (e) {
-            notificationContext.notify(t('label.errors.' + (e.name ? e.name : 'Error')));
+            notificationContext.notify(t('label.errors.' + (e.name ? e.name : 'Error')), ['closeButton', 'noAutomaticClose']);
         }
     };
 

--- a/src/javascript/components/Publication.jsx
+++ b/src/javascript/components/Publication.jsx
@@ -30,7 +30,7 @@ class Publication extends React.Component {
         this.publish = function () {
             vanityMutationsContext.publish(_.map(this.props.urlPairs, 'uuid'));
             props.onClose();
-            notificationContext.notify(t('label.notifications.publicationStarted'));
+            notificationContext.notify(t('label.notifications.publicationStarted'), ['closeAfter5s']);
         };
     }
 

--- a/src/javascript/components/actions/PublishAllAction.jsx
+++ b/src/javascript/components/actions/PublishAllAction.jsx
@@ -37,7 +37,7 @@ const PublishAllActionCmp = ({render: Render, loading: Loading, label, nodeData,
 
     const publish = () => {
         client.mutate({mutation: PublishMutation, variables: {pathsOrIds: unpublishedVanityUrlIds, publishSubNodes: false}}).then(() => {
-            notificationContext.notify(t('label.notifications.publicationStarted'));
+            notificationContext.notify(t('label.notifications.publicationStarted'), ['closeAfter5s']);
         });
     };
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22303

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add automatic close behaviour for notifications, and close button for any error toast messages