### PR TITLE
QA-15066: upgrade jahia version to 8.1.8.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.1.0.0</version>
+        <version>8.1.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>site-settings-seo</artifactId>
     <version>4.5.0-SNAPSHOT</version>


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-15061

Set the minimal parent version to 8.1.8.0-SNAPSHOT because it requires the upgrade of the z-index done in https://github.com/Jahia/jahia-private/pull/2100.
Without the update of the z-index, the publication modal is displayed under content-editor