### PR TITLE
BACKLOG-23131: Modify labels, constraints for SEO description field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
                             <goal>install-node-and-yarn</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v18.15.0</nodeVersion>
-                            <yarnVersion>v1.22.10</yarnVersion>
+                            <nodeVersion>v18.18.0</nodeVersion>
+                            <yarnVersion>v1.22.19</yarnVersion>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -1,0 +1,25 @@
+{
+  "nodeType": "jmix:mainResource",
+  "priority": 2.0,
+  "sections": [
+    {
+      "name": "seo",
+      "fieldSets": [
+        {
+          "name": "jmix:description",
+          "labelKey": "seo.htmlHeadSection.label",
+          "fields": [
+            {
+              "name": "jcr:description",
+              "labelKey": "seo.metaDescription.label",
+              "descriptionKey": "seo.metaDescription.ui.tooltip",
+              "selectorOptionsMap": {
+                "maxLength": 160
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -6,13 +6,14 @@
       "name": "seo",
       "fieldSets": [
         {
-          "name": "jmix:description",
-          "labelKey": "seo.htmlHeadSection.label",
+          "name": "htmlHead",
+          "labelKey": "site-settings-seo:seo.htmlHeadSection.label",
           "fields": [
             {
               "name": "jcr:description",
-              "labelKey": "seo.metaDescription.label",
-              "descriptionKey": "seo.metaDescription.ui.tooltip",
+              "declaringNodeType": "jmix:description",
+              "labelKey": "site-settings-seo:seo.metaDescription.label",
+              "descriptionKey": "site-settings-seo:seo.metaDescription.ui.tooltip",
               "selectorOptionsMap": {
                 "maxLength": 160
               }

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
@@ -1,0 +1,25 @@
+{
+  "nodeType": "jnt:page",
+  "priority": 2.0,
+  "sections": [
+    {
+      "name": "seo",
+      "fieldSets": [
+        {
+          "name": "jmix:description",
+          "labelKey": "seo.htmlHeadSection.label",
+          "fields": [
+            {
+              "name": "jcr:description",
+              "labelKey": "seo.metaDescription.label",
+              "descriptionKey": "seo.metaDescription.ui.tooltip",
+              "selectorOptionsMap": {
+                "maxLength": 160
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
@@ -6,13 +6,14 @@
       "name": "seo",
       "fieldSets": [
         {
-          "name": "jmix:description",
-          "labelKey": "seo.htmlHeadSection.label",
+          "name": "htmlHead",
+          "labelKey": "site-settings-seo:seo.htmlHeadSection.label",
           "fields": [
             {
               "name": "jcr:description",
-              "labelKey": "seo.metaDescription.label",
-              "descriptionKey": "seo.metaDescription.ui.tooltip",
+              "declaringNodeType": "jmix:description",
+              "labelKey": "site-settings-seo:seo.metaDescription.label",
+              "descriptionKey": "site-settings-seo:seo.metaDescription.ui.tooltip",
               "selectorOptionsMap": {
                 "maxLength": 160
               }

--- a/src/main/resources/resources/site-settings-seo_de.properties
+++ b/src/main/resources/resources/site-settings-seo_de.properties
@@ -3,3 +3,9 @@ label.permission.siteAdminUrlmapping=SEO & Vanity-URLs
 label.permission.siteAdminUrlmapping.description=Zugriff auf SEO-Funktionen in jContent => Zusätzlich, einschließlich Vanity-URLs Dashboard.
 label.permission.viewVanityUrlModal.description=Bearbeiten Sie Vanity-URLs für Website
 siteSettingsSeo.title=URL-Mappings
+
+# json override labels
+seo.htmlHeadSection.label=HTML head
+seo.metaDescription.label=Meta Description tag
+seo.metaDescription.ui.tooltip=Das Meta Description tag ist sehr wichtig für Ihre SEO. Halten Sie es einfach und informativ. Am besten \
+  beschränken Sie die Beschreibung auf 160 Zeichen

--- a/src/main/resources/resources/site-settings-seo_en.properties
+++ b/src/main/resources/resources/site-settings-seo_en.properties
@@ -3,3 +3,8 @@ label.permission.siteAdminUrlmapping=SEO & Vanity URLs
 label.permission.siteAdminUrlmapping.description=Access to SEO features in jContent => Additional, including vanity URLs dashboard
 label.permission.viewVanityUrlModal.description=Edit Vanity URLs for site
 siteSettingsSeo.title=Vanity URLs
+
+# json override labels
+seo.htmlHeadSection.label=HTML head
+seo.metaDescription.label=Meta Description tag
+seo.metaDescription.ui.tooltip=The Meta description tag is very important for your SEO. Keep it simple and informative. Best practice is to limit the description to 160 characters

--- a/src/main/resources/resources/site-settings-seo_fr.properties
+++ b/src/main/resources/resources/site-settings-seo_fr.properties
@@ -3,3 +3,9 @@ label.permission.siteAdminUrlmapping=SEO & URL personnalisées
 label.permission.siteAdminUrlmapping.description=Accès aux fonctionnalités SEO dans jContent => Extensions, y compris le tableau de bord des URLs personnalisées.
 label.permission.viewVanityUrlModal.description=Modifier les URL personnalisées pour le site
 siteSettingsSeo.title=URL personnalisées
+
+# json override labels
+seo.htmlHeadSection.label=HTML head
+seo.metaDescription.label=Meta Description tag
+seo.metaDescription.ui.tooltip=Le Meta Description tag est très important pour votre référencement. Restez simple et informatif. La \
+  meilleure pratique consiste à limiter la description à 160 caractères


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23131

Move jcr:description field to a new `htmlHead` fieldSet for `jnt:page` and `jmix:mainResource` nodetypes (in prep for upcoming fields) and also update labels, constraints