### PR TITLE
BACKLOG-23131: Add new i18n keywords field in SEO section

### DIFF
--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -6,4 +6,4 @@
 
 [jmix:seoHtmlHead] mixin
  extends = jnt:page, jmix:mainResource
- - seoKeywords (string, tag[autocomplete=10,separator=',']) i18n facetable nofulltext multiple
+ - seoKeywords (string, tag[autocomplete=10,separator=',']) i18n facetable nofulltext multiple < '.{0,255}'

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -3,3 +3,7 @@
 <mix = 'http://www.jcp.org/jcr/mix/1.0'>
 
 [jmix:canHaveVanityUrls] mixin
+
+[jmix:seoKeywords] mixin
+ extends = jnt:page, jmix:mainResource
+ - keywords (string, tag[autocomplete=10,separator=',']) i18n facetable nofulltext multiple

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -4,6 +4,6 @@
 
 [jmix:canHaveVanityUrls] mixin
 
-[jmix:seoKeywords] mixin
+[jmix:seoHtmlHead] mixin
  extends = jnt:page, jmix:mainResource
- - keywords (string, tag[autocomplete=10,separator=',']) i18n facetable nofulltext multiple
+ - seoKeywords (string, tag[autocomplete=10,separator=',']) i18n facetable nofulltext multiple

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -17,8 +17,18 @@
               "selectorOptionsMap": {
                 "maxLength": 160
               }
+            },
+            {
+              "name": "keywords",
+              "declaringNodeType": "jmix:seoKeywords"
             }
           ]
+        },
+        {
+          "name": "jmix:seoKeywords",
+          "isAlwaysActivated": true,
+          "alwaysPresent": true,
+          "hide": true
         }
       ]
     }

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -19,13 +19,13 @@
               }
             },
             {
-              "name": "keywords",
-              "declaringNodeType": "jmix:seoKeywords"
+              "name": "seoKeywords",
+              "declaringNodeType": "jmix:seoHtmlHead"
             }
           ]
         },
         {
-          "name": "jmix:seoKeywords",
+          "name": "jmix:seoHtmlHead",
           "isAlwaysActivated": true,
           "alwaysPresent": true,
           "hide": true

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
@@ -17,8 +17,18 @@
               "selectorOptionsMap": {
                 "maxLength": 160
               }
+            },
+            {
+              "name": "keywords",
+              "declaringNodeType": "jmix:seoKeywords"
             }
           ]
+        },
+        {
+          "name": "jmix:seoKeywords",
+          "isAlwaysActivated": true,
+          "alwaysPresent": true,
+          "hide": true
         }
       ]
     }

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
@@ -19,13 +19,13 @@
               }
             },
             {
-              "name": "keywords",
-              "declaringNodeType": "jmix:seoKeywords"
+              "name": "seoKeywords",
+              "declaringNodeType": "jmix:seoHtmlHead"
             }
           ]
         },
         {
-          "name": "jmix:seoKeywords",
+          "name": "jmix:seoHtmlHead",
           "isAlwaysActivated": true,
           "alwaysPresent": true,
           "hide": true

--- a/src/main/resources/resources/site-settings-seo_de.properties
+++ b/src/main/resources/resources/site-settings-seo_de.properties
@@ -4,8 +4,8 @@ label.permission.siteAdminUrlmapping.description=Zugriff auf SEO-Funktionen in j
 label.permission.viewVanityUrlModal.description=Bearbeiten Sie Vanity-URLs für Website
 siteSettingsSeo.title=URL-Mappings
 
-jmix_seoKeywords.keywords=Meta Keywords tags
-jmix_seoKeywords.keywords.ui.tooltip=Keywords sind sprachspezifisch. Jedes Keyword muss durch ein Komma "," getrennt werden. \
+jmix_seoHtmlHead.seoKeywords=Meta Keywords tags
+jmix_seoHtmlHead.seoKeywords.ui.tooltip=Keywords sind sprachspezifisch. Jedes Keyword muss durch ein Komma "," getrennt werden. \
   Keywords werden nicht von allen Suchmaschinen verwendet.
 
 # json override labels

--- a/src/main/resources/resources/site-settings-seo_de.properties
+++ b/src/main/resources/resources/site-settings-seo_de.properties
@@ -4,6 +4,10 @@ label.permission.siteAdminUrlmapping.description=Zugriff auf SEO-Funktionen in j
 label.permission.viewVanityUrlModal.description=Bearbeiten Sie Vanity-URLs für Website
 siteSettingsSeo.title=URL-Mappings
 
+jmix_seoKeywords.keywords=Meta Keywords tags
+jmix_seoKeywords.keywords.ui.tooltip=Schlüsselwörter sind sprachspezifisch. Jedes Schlüsselwort muss durch ein Komma "," getrennt werden. \
+  Schlüsselwörter werden nicht von allen Suchmaschinen verwendet.
+
 # json override labels
 seo.htmlHeadSection.label=HTML head
 seo.metaDescription.label=Meta Description tag

--- a/src/main/resources/resources/site-settings-seo_de.properties
+++ b/src/main/resources/resources/site-settings-seo_de.properties
@@ -5,8 +5,8 @@ label.permission.viewVanityUrlModal.description=Bearbeiten Sie Vanity-URLs für W
 siteSettingsSeo.title=URL-Mappings
 
 jmix_seoKeywords.keywords=Meta Keywords tags
-jmix_seoKeywords.keywords.ui.tooltip=Schlüsselwörter sind sprachspezifisch. Jedes Schlüsselwort muss durch ein Komma "," getrennt werden. \
-  Schlüsselwörter werden nicht von allen Suchmaschinen verwendet.
+jmix_seoKeywords.keywords.ui.tooltip=Keywords sind sprachspezifisch. Jedes Keyword muss durch ein Komma "," getrennt werden. \
+  Keywords werden nicht von allen Suchmaschinen verwendet.
 
 # json override labels
 seo.htmlHeadSection.label=HTML head

--- a/src/main/resources/resources/site-settings-seo_en.properties
+++ b/src/main/resources/resources/site-settings-seo_en.properties
@@ -4,8 +4,8 @@ label.permission.siteAdminUrlmapping.description=Access to SEO features in jCont
 label.permission.viewVanityUrlModal.description=Edit Vanity URLs for site
 siteSettingsSeo.title=Vanity URLs
 
-jmix_seoKeywords.keywords=Meta Keywords tags
-jmix_seoKeywords.keywords.ui.tooltip=Keywords are specific to each language. Each keyword must be separated by a comma ",". \
+jmix_seoHtmlHead.seoKeywords=Meta Keywords tags
+jmix_seoHtmlHead.seoKeywords.ui.tooltip=Keywords are specific to each language. Each keyword must be separated by a comma ",". \
   Keywords are not used by all search engines.
 
 # json override labels

--- a/src/main/resources/resources/site-settings-seo_en.properties
+++ b/src/main/resources/resources/site-settings-seo_en.properties
@@ -4,6 +4,10 @@ label.permission.siteAdminUrlmapping.description=Access to SEO features in jCont
 label.permission.viewVanityUrlModal.description=Edit Vanity URLs for site
 siteSettingsSeo.title=Vanity URLs
 
+jmix_seoKeywords.keywords=Meta Keywords tags
+jmix_seoKeywords.keywords.ui.tooltip=Keywords are specific to each language. Each keyword must be separated by a comma ",". \
+  Keywords are not used by all search engines.
+
 # json override labels
 seo.htmlHeadSection.label=HTML head
 seo.metaDescription.label=Meta Description tag

--- a/src/main/resources/resources/site-settings-seo_fr.properties
+++ b/src/main/resources/resources/site-settings-seo_fr.properties
@@ -5,8 +5,8 @@ label.permission.viewVanityUrlModal.description=Modifier les URL personnalisées 
 siteSettingsSeo.title=URL personnalisées
 
 jmix_seoKeywords.keywords=Meta Keywords tags
-jmix_seoKeywords.keywords.ui.tooltip=Les mots-clés sont spécifiques à chaque langue. Chaque mot-clé doit être séparé par une virgule ",". \
-  Les mots-clés ne sont pas utilisés par tous les moteurs de recherche.
+jmix_seoKeywords.keywords.ui.tooltip=Les keywords sont spécifiques à chaque langue, et doivent être séparés par une virgule ",". \
+  Certains moteurs de recherche n'utilise pas les "keywords".
 
 # json override labels
 seo.htmlHeadSection.label=HTML head

--- a/src/main/resources/resources/site-settings-seo_fr.properties
+++ b/src/main/resources/resources/site-settings-seo_fr.properties
@@ -4,8 +4,8 @@ label.permission.siteAdminUrlmapping.description=Accès aux fonctionnalités SEO d
 label.permission.viewVanityUrlModal.description=Modifier les URL personnalisées pour le site
 siteSettingsSeo.title=URL personnalisées
 
-jmix_seoKeywords.keywords=Meta Keywords tags
-jmix_seoKeywords.keywords.ui.tooltip=Les keywords sont spécifiques à chaque langue, et doivent être séparés par une virgule ",". \
+jmix_seoHtmlHead.seoKeywords=Meta Keywords tags
+jmix_seoHtmlHead.seoKeywords.ui.tooltip=Les keywords sont spécifiques à chaque langue, et doivent être séparés par une virgule ",". \
   Certains moteurs de recherche n'utilise pas les "keywords".
 
 # json override labels

--- a/src/main/resources/resources/site-settings-seo_fr.properties
+++ b/src/main/resources/resources/site-settings-seo_fr.properties
@@ -4,6 +4,10 @@ label.permission.siteAdminUrlmapping.description=Accès aux fonctionnalités SEO d
 label.permission.viewVanityUrlModal.description=Modifier les URL personnalisées pour le site
 siteSettingsSeo.title=URL personnalisées
 
+jmix_seoKeywords.keywords=Meta Keywords tags
+jmix_seoKeywords.keywords.ui.tooltip=Les mots-clés sont spécifiques à chaque langue. Chaque mot-clé doit être séparé par une virgule ",". \
+  Les mots-clés ne sont pas utilisés par tous les moteurs de recherche.
+
 # json override labels
 seo.htmlHeadSection.label=HTML head
 seo.metaDescription.label=Meta Description tag


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23131

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add new `jmix:seoHtmlHead` mixin that has i18n keyword field using tag selector. 

This is added under HTML head fieldset in SEO section using json overrides.

This also makes use of the new `isAlwaysActivated` fieldset json override property in order to remove the toggle for jmix:seoKeywords fieldset in CE modal https://github.com/Jahia/jcontent/pull/1296