### PR TITLE
BACKLOG-23132: Add jahia-depends for jcontent version 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <description>This is the custom module (Site Settings - SEO) for running on a Digital Experience Manager server.</description>
     <properties>
         <jahia.plugin.version>6.9</jahia.plugin.version>
-        <jahia-depends>graphql-dxm-provider, jcontent=3, seo,app-shell=2.6</jahia-depends>
+        <jahia-depends>graphql-dxm-provider, jcontent=3.1, seo,app-shell=2.6</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>all</jahia-deploy-on-site>
         <yarn.arguments>build:simple</yarn.arguments>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23132
## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Bumping jahia-depends to jcontent 3.1 as it's needed to use new `isAlwaysActivated` json override from jcontent to properly make new SEO keywords field display properly.  https://github.com/Jahia/site-settings-seo/pull/242

Installing with jcontent lower version will break saving on jnt:page and jmix:mainResource components.

Leaving major version as-is, as I'm not sure major version bump is needed in this case.
