### PR TITLE
Configured step-level timeouts to give enough time for the CI to wrapup the job

### DIFF
--- a/.github/workflows/nightly-rl.yml
+++ b/.github/workflows/nightly-rl.yml
@@ -10,7 +10,7 @@ jobs:
     name: Integration Tests
     runs-on: self-hosted
 
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main
@@ -24,6 +24,7 @@ jobs:
         with:
           module_id: site-settings-seo
           incident_service: site-settings-seo-JahiaRL
+          timeout_minutes: 45
           jahia_image: jahia/jahia-ee:8
           testrail_project: SEO Module
           tests_manifest: provisioning-manifest-snapshot.yml

--- a/.github/workflows/nightly-sn.yml
+++ b/.github/workflows/nightly-sn.yml
@@ -10,7 +10,7 @@ jobs:
     name: Integration Tests
     runs-on: self-hosted
 
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main
@@ -24,6 +24,7 @@ jobs:
         with:
           module_id: site-settings-seo
           incident_service: site-settings-seo-JahiaSN
+          timeout_minutes: 45
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           testrail_project: SEO Module
           tests_manifest: provisioning-manifest-snapshot.yml

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -62,7 +62,7 @@ jobs:
     name: Integration Tests (Cluster)
     needs: build
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main
@@ -76,6 +76,7 @@ jobs:
         with:
           module_id: site-settings-seo
           testrail_project: SEO Module
+          timeout_minutes: 45
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           jahia_cluster_enabled: true

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -71,7 +71,7 @@ jobs:
     name: Integration Tests (Standalone)
     needs: build
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main
@@ -85,6 +85,7 @@ jobs:
         with:
           module_id: site-settings-seo
           testrail_project: SEO Module
+          timeout_minutes: 45
           tests_manifest: provisioning-manifest-build.yml
           #TODO TECH-1408 reactive the test on released version
           #jahia_image: jahia/jahia-ee-dev:8


### PR DESCRIPTION
This PR does not increase the time given to a job to process its tests, it is giving more time for the CI to collect artifacts if a timeout is reached and create pagerduty incidents when needed.