### PR TITLE
Add missing required dependencies in provisioning

### DIFF
--- a/.github/workflows/nightly-rl.yml
+++ b/.github/workflows/nightly-rl.yml
@@ -26,7 +26,7 @@ jobs:
           incident_service: site-settings-seo-JahiaRL
           jahia_image: jahia/jahia-ee:8
           testrail_project: SEO Module
-          tests_manifest: provisioning-manifest-snapshot.yml
+          tests_manifest: provisioning-manifest-release.yml
           should_use_build_artifacts: false
           should_skip_artifacts: true
           should_skip_notifications: true

--- a/tests/provisioning-manifest-release.yml
+++ b/tests/provisioning-manifest-release.yml
@@ -1,0 +1,37 @@
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
+  username: ${env:NEXUS_USERNAME}
+  password: ${env:NEXUS_PASSWORD}
+
+- installBundle:
+    - 'mvn:org.jahia.modules/legacy-default-components'
+    - 'mvn:org.jahia.modules/graphql-dxm-provider'
+    - 'mvn:org.jahia.modules/event'
+    - 'mvn:org.jahia.modules/press'
+    - 'mvn:org.jahia.modules/person'
+    - 'mvn:org.jahia.modules/news'
+    - 'mvn:org.jahia.modules/font-awesome'
+    - 'mvn:org.jahia.modules/calendar'
+    - 'mvn:org.jahia.modules/bootstrap3-core'
+    - 'mvn:org.jahia.modules/bootstrap3-components'
+    - 'mvn:org.jahia.modules/location'
+    - 'mvn:org.jahia.modules/topstories'
+    - 'mvn:org.jahia.modules/rating'
+    - 'mvn:org.jahia.modules/bookmarks'
+    - 'mvn:org.jahia.modules/dx-base-demo-core'
+    - 'mvn:org.jahia.modules/dx-base-demo-templates'
+    - 'mvn:org.jahia.modules/dx-base-demo-components'
+    - 'mvn:org.jahia.modules/digitall/3.0.0'
+    - 'mvn:org.jahia.modules/skins'
+    - 'mvn:org.jahia.modules/default-skins'
+    - 'mvn:org.jahia.modules/grid'
+    - 'mvn:org.jahia.modules/tabularList'
+    - 'mvn:org.jahia.modules/jahia-ui-root/1.10.0'
+    - 'mvn:org.jahia.modules/jcontent/3.1.0'
+    - 'mvn:org.jahia.modules/site-settings-seo'
+    - 'mvn:org.jahia.test/site-settings-seo-test-module'
+  autoStart: true
+  uninstallPreviousVersion: true
+
+- import: "jar:mvn:org.jahia.modules/digitall/3.0.0/zip/import!/users.zip"
+- importSite: "jar:mvn:org.jahia.modules/digitall/3.0.0/zip/import!/Digitall.zip"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Create separate provisioning for nightly release, and add required dependencies with latest site-settings-seo changes, e.g. jcontent >= 3.1.0 and jahia-ui-root >= 1.10.0.

Note that there is an existing issue with latest jahia release images (8 tags are currently pointing to 8.1, not 8.2) so this might still fail until image tags are fixed.