### PR TITLE
TECH-1880: fix seo tests

### DIFF
--- a/tests/cypress/e2e/seoOverrides/definitions.cy.ts
+++ b/tests/cypress/e2e/seoOverrides/definitions.cy.ts
@@ -21,7 +21,7 @@ describe('New SEO field definition tests', () => {
     it('should have new SEO fields for pages and can be saved', function () {
         const ce = JContent.visit(siteKey, 'en', 'pages/home').editPage()
 
-        ce.openSection('SEO')
+        ce.openSection('seo')
         ce.getField(Field, 'htmlHead_jcr:description').should('exist').and('be.visible')
         ce.getField(Field, 'htmlHead_seoKeywords').should('exist').and('be.visible')
         ce.getField(Field, 'htmlHead_openGraphImage').should('exist').and('be.visible')
@@ -42,7 +42,7 @@ describe('New SEO field definition tests', () => {
     })
 
     it('should not have new SEO fields for other types', function () {
-        JContent.visit(siteKey, 'en', 'content-folders/contents').createContent('Rich text').openSection('SEO')
+        JContent.visit(siteKey, 'en', 'content-folders/contents').createContent('Rich text').openSection('seo')
         const assertFieldNotExist = (contentType) => {
             cy.get(`[data-sel-content-editor-field="${contentType}"]`).should('not.exist', { timeout: 10000 })
         }


### PR DESCRIPTION
## Description

Some SEO tests were failing because we modified some data-sel attributes in jcontent/ content-editor.

New SEO field definition tests
- should have new SEO fields for pages and can be saved
- should not have new SEO fields for other types
