### PR TITLE
BACKLOG-23347: Show SEO section only for certain nodetypes

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
           skip_lint_modules: true
-          node_version: 14
           auditci_level: critical
 
   build:

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -9,6 +9,7 @@
         {
           "name": "htmlHead",
           "labelKey": "site-settings-seo:seo.htmlHeadSection.label",
+          "rank": 0.1,
           "fields": [
             {
               "name": "jcr:description",
@@ -31,6 +32,7 @@
         },
         {
           "name": "jmix:seoHtmlHead",
+          "rank": 0.2,
           "isAlwaysActivated": true,
           "alwaysPresent": true,
           "hide": true

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -4,6 +4,7 @@
   "sections": [
     {
       "name": "seo",
+      "hide": false,
       "fieldSets": [
         {
           "name": "htmlHead",

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
@@ -9,6 +9,7 @@
         {
           "name": "htmlHead",
           "labelKey": "site-settings-seo:seo.htmlHeadSection.label",
+          "rank": 0.1,
           "fields": [
             {
               "name": "jcr:description",
@@ -31,6 +32,7 @@
         },
         {
           "name": "jmix:seoHtmlHead",
+          "rank": 0.2,
           "isAlwaysActivated": true,
           "alwaysPresent": true,
           "hide": true

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json
@@ -4,6 +4,7 @@
   "sections": [
     {
       "name": "seo",
+      "hide": false,
       "fieldSets": [
         {
           "name": "htmlHead",

--- a/tests/cypress/e2e/seoOverrides/definitions.cy.ts
+++ b/tests/cypress/e2e/seoOverrides/definitions.cy.ts
@@ -77,8 +77,10 @@ describe('New SEO field definition tests', () => {
         })
     })
 
-    it('should not have new SEO fields for other types', function () {
-        JContent.visit(siteKey, 'en', 'content-folders/contents').createContent('Rich text').openSection('seo')
+    it('should not have SEO section and new SEO fields for other types', function () {
+        JContent.visit(siteKey, 'en', 'content-folders/contents').createContent('Rich text')
+        cy.get(`[data-sel-content-editor-fields-group="seo"]`).should('not.exist', { timeout: 10000 })
+
         const assertFieldNotExist = (contentType) => {
             cy.get(`[data-sel-content-editor-field="${contentType}"]`).should('not.exist', { timeout: 10000 })
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23347
https://jira.jahia.org/browse/BACKLOG-23500

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Show SEO section only for `jnt:page` and `jmix:mainResource` nodetypes (disabled by default on jcontent override)
- Add priority ordering for seo fields 
- updated tests

Related PR: https://github.com/Jahia/jcontent/pull/1391