### PR TITLE
BACKLOG-23432: Make SEO keywords field searchable

### DIFF
--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -6,5 +6,5 @@
 
 [jmix:seoHtmlHead] mixin
  extends = jnt:page, jmix:mainResource
- - seoKeywords (string, tag[autocomplete=10,separator=',']) i18n facetable nofulltext multiple < '.{0,255}'
+ - seoKeywords (string, tag[autocomplete=10,separator=',']) i18n facetable multiple < '.{0,255}'
  - openGraphImage (weakreference, picker[type='image']) < 'jmix:image'

--- a/tests/cypress/e2e/fields/seoKeywords.cy.ts
+++ b/tests/cypress/e2e/fields/seoKeywords.cy.ts
@@ -39,23 +39,13 @@ describe('SEO keywords tests', () => {
         cy.loginAndStoreSession()
     })
 
-    it('should be able to search for seo keywords tag', { retries: 3 }, function () {
-        const searchTagInLang = (lang) => {
-            cy.log(`Search for ${searchTag[lang]} in ${lang} site`)
-            cy.visit(`cms/render/default/${lang}/sites/${siteKey}/home/search-results.html`)
-            cy.get('.search-block input[type="text"]').type(`${searchTag[lang]}{enter}`)
-            cy.get('.s-results').contains(searchTag[lang], { timeout: 10000 }).should('be.visible')
-        }
-        searchTagInLang('en')
-        searchTagInLang('fr')
-    })
-
     it('should be possible to edit SEO fields : adding a new value', function () {
         const ce = JContent.visit(siteKey, 'en', `pages/home/${pageName_addTest}`).editPage()
 
         ce.openSection('seo')
 
         const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
+        tagField.get().find('#htmlHead_seoKeywords').click()
         tagField.get().find('#htmlHead_seoKeywords').type('newtag{enter}', { delay: 500 })
         tagField
             .should('exist')
@@ -78,14 +68,25 @@ describe('SEO keywords tests', () => {
         ce.openSection('seo')
 
         const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
-        tagField.get().find('#htmlHead_seoKeywords').find('span:contains("test1en")').siblings('svg').click()
+        tagField.get().find('#htmlHead_seoKeywords').find('span:contains("test2en")').siblings('svg').click()
         tagField.should('exist').and('be.visible').and('contain', 'test2en')
         ce.save()
 
         getNodeByPath(`/sites/${siteKey}/home/${pageName_removeTest}`, ['seoKeywords']).then(({ data }) => {
             expect(data.jcr.nodeByPath.properties.length).to.eq(1)
             expect(data.jcr.nodeByPath.properties[0].values.length).to.eq(1)
-            expect(data.jcr.nodeByPath.properties[0].values[0]).to.eq('test2en')
+            expect(data.jcr.nodeByPath.properties[0].values[0]).to.eq('test1en')
         })
+    })
+
+    it('should be able to search for seo keywords tag', function () {
+        const searchTagInLang = (lang) => {
+            cy.log(`Search for ${searchTag[lang]} in ${lang} site`)
+            cy.visit(`cms/render/default/${lang}/sites/${siteKey}/home/search-results.html`)
+            cy.get('.search-block input[type="text"]').type(`${searchTag[lang]}{enter}`)
+            cy.get('.s-results').contains(searchTag[lang], { timeout: 10000 }).should('be.visible')
+        }
+        searchTagInLang('en')
+        searchTagInLang('fr')
     })
 })

--- a/tests/cypress/e2e/fields/seoKeywords.cy.ts
+++ b/tests/cypress/e2e/fields/seoKeywords.cy.ts
@@ -1,0 +1,91 @@
+import { addNode, createSite, deleteSite, getNodeByPath } from '@jahia/cypress'
+import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
+import { Field } from '@jahia/jcontent-cypress/dist/page-object/fields/field'
+
+describe('SEO keywords tests', () => {
+    const siteKey = 'seoKeywordsTest'
+    const pageName_addTest = 'pagetest_addTag'
+    const pageName_removeTest = 'pagetest_removeTag'
+    const searchTag = { en: 'test1en', fr: 'test1fr' }
+
+    const createPageWithSEOKeyword = (pageName: string) => {
+        return addNode({
+            parentPathOrId: `/sites/${siteKey}/home`,
+            name: pageName,
+            primaryNodeType: 'jnt:page',
+            mixins: ['jmix:seoHtmlHead'],
+            properties: [
+                { name: 'j:templateName', value: 'simple' },
+                { name: 'jcr:title', language: 'en', value: pageName },
+                { name: 'jcr:title', language: 'fr', value: pageName },
+                { name: 'seoKeywords', language: 'en', values: [searchTag.en, 'test2en'] },
+                { name: 'seoKeywords', language: 'fr', values: [searchTag.fr, 'test2fr'] },
+            ],
+        })
+    }
+
+    before(function () {
+        createSite(siteKey, { templateSet: 'dx-base-demo-templates', serverName: 'localhost', locale: 'en,fr' })
+        createPageWithSEOKeyword(pageName_addTest)
+        createPageWithSEOKeyword(pageName_removeTest)
+    })
+
+    after(function () {
+        deleteSite(siteKey)
+        cy.logout()
+    })
+
+    beforeEach(function () {
+        cy.loginAndStoreSession()
+    })
+
+    it('should be able to search for seo keywords tag', { retries: 3 }, function () {
+        const searchTagInLang = (lang) => {
+            cy.log(`Search for ${searchTag[lang]} in ${lang} site`)
+            cy.visit(`cms/render/default/${lang}/sites/${siteKey}/home/search-results.html`)
+            cy.get('.search-block input[type="text"]').type(`${searchTag[lang]}{enter}`)
+            cy.get('.s-results').contains(searchTag[lang], { timeout: 10000 }).should('be.visible')
+        }
+        searchTagInLang('en')
+        searchTagInLang('fr')
+    })
+
+    it('should be possible to edit SEO fields : adding a new value', function () {
+        const ce = JContent.visit(siteKey, 'en', `pages/home/${pageName_addTest}`).editPage()
+
+        ce.openSection('seo')
+
+        const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
+        tagField.get().find('#htmlHead_seoKeywords').type('newtag{enter}', { delay: 500 })
+        tagField
+            .should('exist')
+            .and('be.visible')
+            .and('contain', 'test1en')
+            .and('contain', 'test2en')
+            .and('contain', 'newtag')
+        ce.save()
+
+        getNodeByPath(`/sites/${siteKey}/home/${pageName_addTest}`, ['seoKeywords']).then(({ data }) => {
+            expect(data.jcr.nodeByPath.properties.length).to.eq(1)
+            expect(data.jcr.nodeByPath.properties[0].values.length).to.eq(3)
+            expect(data.jcr.nodeByPath.properties[0].values).to.contains('newtag')
+        })
+    })
+
+    it('should be possible to edit SEO fields : removing a value', function () {
+        const ce = JContent.visit(siteKey, 'en', `pages/home/${pageName_removeTest}`).editPage()
+
+        ce.openSection('seo')
+
+        const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
+        tagField.get().find('#htmlHead_seoKeywords').find('span:contains("test1en")').siblings('svg').click()
+        tagField.should('exist').and('be.visible').and('contain', 'test2en')
+        ce.save()
+
+        getNodeByPath(`/sites/${siteKey}/home/${pageName_removeTest}`, ['seoKeywords']).then(({ data }) => {
+            expect(data.jcr.nodeByPath.properties.length).to.eq(1)
+            expect(data.jcr.nodeByPath.properties[0].values.length).to.eq(1)
+            expect(data.jcr.nodeByPath.properties[0].values[0]).to.eq('test2en')
+        })
+    })
+})

--- a/tests/cypress/e2e/seoOverrides/definitions.cy.ts
+++ b/tests/cypress/e2e/seoOverrides/definitions.cy.ts
@@ -28,6 +28,7 @@ describe('New SEO field definition tests', () => {
 
         ce.getField(Field, 'htmlHead_jcr:description').get().find('textarea').type('description test')
         const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
+        tagField.get().find('#htmlHead_seoKeywords').click()
         tagField.get().find('#htmlHead_seoKeywords').type('tag{enter}', { delay: 500 })
         tagField.get().find('#htmlHead_seoKeywords [role="button"]').contains('tag').should('be.visible')
 

--- a/tests/cypress/e2e/seoOverrides/definitions.cy.ts
+++ b/tests/cypress/e2e/seoOverrides/definitions.cy.ts
@@ -1,33 +1,12 @@
-import { addNode, createSite, deleteSite, getNodeByPath } from '@jahia/cypress'
+import { createSite, deleteSite, getNodeByPath } from '@jahia/cypress'
 import { JContent } from '@jahia/jcontent-cypress/dist/page-object/jcontent'
 import { Field } from '@jahia/jcontent-cypress/dist/page-object/fields/field'
 
 describe('New SEO field definition tests', () => {
     const siteKey = 'seoFieldsTest'
-    const pageName_addTest = 'pagetest_addTag'
-    const pageName_removeTest = 'pagetest_removeTag'
-    const searchTag = {en: 'test1en', fr: 'test1fr'}
-
-    const createPageWithSEOKeyword = (pageName: string) => {
-        return addNode({
-            parentPathOrId: `/sites/${siteKey}/home`,
-            name: pageName,
-            primaryNodeType: 'jnt:page',
-            mixins: ['jmix:seoHtmlHead'],
-            properties: [
-                {name: 'j:templateName', value: 'simple'},
-                {name: 'jcr:title', language: 'en', value: pageName},
-                {name: 'jcr:title', language: 'fr', value: pageName},
-                {name: 'seoKeywords', language: 'en', values: [searchTag.en, 'test2en']},
-                {name: 'seoKeywords', language: 'fr', values: [searchTag.fr, 'test2fr']}
-            ]
-        })
-    }
 
     before(function () {
-        createSite(siteKey, {templateSet: 'dx-base-demo-templates', serverName: 'localhost', locale: 'en,fr'})
-        createPageWithSEOKeyword(pageName_addTest)
-        createPageWithSEOKeyword(pageName_removeTest)
+        createSite(siteKey)
     })
 
     after(function () {
@@ -78,55 +57,5 @@ describe('New SEO field definition tests', () => {
         assertFieldNotExist('htmlHead_jcr:description')
         assertFieldNotExist('htmlHead_seoKeywords')
         assertFieldNotExist('htmlHead_openGraphImage')
-    })
-
-    it('should be able to search for seo keywords tag', function () {
-        const searchTagInLang = (lang) => {
-            cy.log(`Search for ${searchTag[lang]} in ${lang} site`)
-            cy.visit(`cms/render/default/${lang}/sites/${siteKey}/home/search-results.html`)
-            cy.get('.search-block input[type="text"]').type(`${searchTag[lang]}{enter}`)
-            cy.get('.s-results').contains(searchTag[lang]).should('be.visible')
-        }
-        searchTagInLang('en')
-        searchTagInLang('fr')
-    })
-
-    it('should be possible to edit SEO fields : adding a new value', function () {
-        const ce = JContent.visit(siteKey, 'en', `pages/home/${pageName_addTest}`).editPage()
-
-        ce.openSection('seo')
-
-        const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
-        tagField.get().find('#htmlHead_seoKeywords').type('newtag{enter}', { delay: 500 })
-        tagField
-            .should('exist')
-            .and('be.visible')
-            .and('contain', 'test1en')
-            .and('contain', 'test2en')
-            .and('contain', 'newtag')
-        ce.save()
-
-        getNodeByPath(`/sites/${siteKey}/home/${pageName_addTest}`, ['seoKeywords']).then(({ data }) => {
-            expect(data.jcr.nodeByPath.properties.length).to.eq(1)
-            expect(data.jcr.nodeByPath.properties[0].values.length).to.eq(3)
-            expect(data.jcr.nodeByPath.properties[0].values).to.contains('newtag')
-        })
-    })
-
-    it('should be possible to edit SEO fields : removing a value', function () {
-        const ce = JContent.visit(siteKey, 'en', `pages/home/${pageName_removeTest}`).editPage()
-
-        ce.openSection('seo')
-
-        const tagField = ce.getField(Field, 'htmlHead_seoKeywords')
-        tagField.get().find('#htmlHead_seoKeywords').find('span:contains("test1en")').siblings('svg').click()
-        tagField.should('exist').and('be.visible').and('contain', 'test2en')
-        ce.save()
-
-        getNodeByPath(`/sites/${siteKey}/home/${pageName_removeTest}`, ['seoKeywords']).then(({ data }) => {
-            expect(data.jcr.nodeByPath.properties.length).to.eq(1)
-            expect(data.jcr.nodeByPath.properties[0].values.length).to.eq(1)
-            expect(data.jcr.nodeByPath.properties[0].values[0]).to.eq('test2en')
-        })
     })
 })

--- a/tests/cypress/e2e/seoOverrides/definitions.cy.ts
+++ b/tests/cypress/e2e/seoOverrides/definitions.cy.ts
@@ -48,9 +48,8 @@ describe('New SEO field definition tests', () => {
         })
     })
 
-    it('should not have SEO section and new SEO fields for other types', function () {
+    it('should not have new SEO fields for other types', function () {
         JContent.visit(siteKey, 'en', 'content-folders/contents').createContent('Rich text')
-        cy.get(`[data-sel-content-editor-fields-group="seo"]`).should('not.exist', { timeout: 10000 })
 
         const assertFieldNotExist = (contentType) => {
             cy.get(`[data-sel-content-editor-field="${contentType}"]`).should('not.exist', { timeout: 10000 })


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

 - Make SEO keywords searchable from definitions by removing nofulltext 
 - Add cypress test for searching seo keywords in multiple language
 - refactor separate test suite for seo keywords