### PR TITLE
fix: color of AddVanityURL button

### DIFF
--- a/src/javascript/components/AddVanityUrl/AddVanityUrl.jsx
+++ b/src/javascript/components/AddVanityUrl/AddVanityUrl.jsx
@@ -157,7 +157,6 @@ export const AddVanityUrl = ({
             <>
                 {children && children(showInputField)}
                 <Button isDisabled={!hasWritePermission}
-                        className={classes.addVanityButton}
                         aria-label="add"
                         label={t('label.buttons.addVanity')}
                         icon={<Add/>}

--- a/src/javascript/components/AddVanityUrl/AddVanityUrl.scss
+++ b/src/javascript/components/AddVanityUrl/AddVanityUrl.scss
@@ -67,15 +67,6 @@
   top: 7px;
 }
 
-.addVanityButton {
-  color: #575757;
-
-  &:hover {
-    background-color: transparent;
-    color: #4A4343
-  }
-}
-
 .row {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
### Description
@sdusolle reported an [issue](https://github.com/Jahia/moonstone/issues/989#issuecomment-2757522663) with the `Add vanity URL` button with the Moonstone version [2.12.2](https://github.com/Jahia/moonstone/releases/tag/v2.12.2) shipped with jContent. 

As the CSS classes of the Moonstone button become more flat, some styles of this module override the style provided by moonstone.

**Note:**
The issue about the button alignment will be [fixed](https://github.com/Jahia/moonstone/pull/999) with the next moonstone release.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
