### PR TITLE
feat: add `x-default` language link

### DIFF
--- a/src/main/java/org/jahia/modules/sitesettingsseo/SeoUrlFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettingsseo/SeoUrlFilter.java
@@ -118,7 +118,7 @@ public class SeoUrlFilter extends AbstractFilter {
         }
     }
 
-    private String getLinkForLang(JCRNodeWrapper node, Map<String, String> vanities, String lang, RenderContext renderContext, Set<String> langs) throws URISyntaxException {
+    private String getLinkForLang(JCRNodeWrapper node, Map<String, String> vanities, String lang, RenderContext renderContext, Set<String> langs) throws URISyntaxException, RepositoryException {
         String url = vanities.containsKey(lang) ?
                 vanities.get(lang) :
                 renderContext.getURLGenerator().buildURL(node, lang, null, "html");
@@ -130,6 +130,10 @@ public class SeoUrlFilter extends AbstractFilter {
         }
 
         String links = String.format("<link rel=\"alternate\" hreflang=\"%s\" href=\"%s\" />", getDashFormatLanguage(lang), href);
+        // Add x-default language metatag for site default language
+        links += node.getResolveSite().getDefaultLanguage().equals(lang) ?
+                String.format("\n<link rel=\"alternate\" hreflang=\"%s\" href=\"%s\" />", "x-default", href) :
+                "";
         return node.getLanguage().equals(lang) ?
                 String.format("<link rel=\"canonical\" href=\"%s\" />", href) + links:
                 links;

--- a/tests/cypress/e2e/multilang.site.test.cy.ts
+++ b/tests/cypress/e2e/multilang.site.test.cy.ts
@@ -29,6 +29,7 @@ describe('Basic tests of seo filter for multilingual site', () => {
     }
 
     before('create test data', function () {
+        deleteSite(siteKey)
         createSite(siteKey, siteConfig)
         createPage(homePath, pageName, 'withoutseo', langEN)
         setNodeProperty(homePath, 'jcr:title', 'home-fr', 'fr')
@@ -55,6 +56,10 @@ describe('Basic tests of seo filter for multilingual site', () => {
             .should('have.attr', 'href', Cypress.config().baseUrl + pagePath + '.html')
         cy.get('link[rel="alternate"]')
             .eq(1)
+            .should('have.attr', 'href', Cypress.config().baseUrl + pagePath + '.html')
+            .should('have.attr', 'hreflang', 'x-default')
+        cy.get('link[rel="alternate"]')
+            .eq(2)
             .should('have.attr', 'href', Cypress.config().baseUrl + '/' + langFR + pagePath + '.html')
     })
 })

--- a/tests/env.run.sh
+++ b/tests/env.run.sh
@@ -118,13 +118,8 @@ fi
 CYPRESS_CONFIG="cypress.config.ts"
 
 echo "$(date +'%d %B %Y - %k:%M') == Run tests with config: ${CYPRESS_CONFIG} =="
-if [[ "${JAHIA_CLUSTER_ENABLED}" == "true" ]]; then
-  echo "$(date +'%d %B %Y - %k:%M') == Run ALL specs with cluster enabled =="
-  yarn e2e:${RUN} --config-file ${CYPRESS_CONFIG}
-else
-  echo "$(date +'%d %B %Y - %k:%M') == Run REDUCED specs with cluster disabled =="
-  yarn e2e:ci:standalone --config-file ${CYPRESS_CONFIG}
-fi
+
+yarn e2e:${RUN} --config-file ${CYPRESS_CONFIG}
 
 if [[ $? -eq 0 ]]; then
   echo "$(date +'%d %B %Y - %k:%M') == Full execution successful =="

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,6 @@
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",
     "e2e:debug": "cypress open",
-    "e2e:ci:standalone": "cypress run --browser chrome",
     "lint": "eslint . -c .eslintrc.json --ext .ts",
     "report:merge": "mochawesome-merge results/reports/cypress*.json > results/reports/report.json && rm results/reports/cypress*.json",
     "report:html": "marge --inline results/reports/report.json --reportDir results/reports/"


### PR DESCRIPTION
In case of several languages and `hreflang` links being generated (they are not if they are already part of the templates set), the `x-default` `hreflang` link is added, it matches the link to the default language of the site

### Testing 
Check that the `link` tag with `hreflang` attribute set to `x-default` is part of the headers

### Cypress changes
Clean up in the script to be able to run the debug (cypress in local)