### PR TITLE
fix: Add icon for vanity url action

### DIFF
--- a/src/javascript/components/Register/registerActions.js
+++ b/src/javascript/components/Register/registerActions.js
@@ -1,12 +1,13 @@
 import {registry} from '@jahia/ui-extender';
 import {MoveVanityAction, PublishAllAction, PublishVanityAction, UpdateVanityAction, VanityAction} from '../actions';
-import {CloudUpload, Publish, Star, SwapHoriz} from '@jahia/moonstone';
+import {CloudUpload, Link, Publish, Star, SwapHoriz} from '@jahia/moonstone';
 import React from 'react';
 
 export const registerActions = () => {
     // Content editor action registration
     registry.add('action', 'vanityUrls', {
         component: VanityAction,
+        buttonIcon: <Link/>,
         targets: ['content-editor/header/3dots:3'],
         requiredPermission: 'viewVanityUrlModal',
         showOnNodeTypes: ['jmix:vanityUrlMapped', 'jnt:page', 'jnt:file', 'jmix:mainResource', 'jmix:canHaveVanityUrls'],

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -7,7 +7,6 @@
     - 'mvn:org.jahia.modules/legacy-default-components'
     - 'mvn:org.jahia.modules/jcontent'
     - 'mvn:org.jahia.modules/event'
-    - 'mvn:org.jahia.modules/site-settings-seo'
     - 'mvn:org.jahia.modules/press'
     - 'mvn:org.jahia.modules/person'
     - 'mvn:org.jahia.modules/news'


### PR DESCRIPTION
Fix should now show up as part of the new CE header buttons

![image](https://github.com/user-attachments/assets/19303689-e043-4d46-9245-b8f4836a7a54)


Also removed site-settings-seo as part of build provisioining (should use built artifacts instead)