### PR TITLE
test: use exist instead of be.visible

### DIFF
--- a/tests/cypress/page-object/ContentEditorSEO.ts
+++ b/tests/cypress/page-object/ContentEditorSEO.ts
@@ -23,6 +23,6 @@ export class ContentEditorSEO extends ContentEditor {
     }
 
     checkVanityUrlVisibility(isVisible) {
-        cy.get('button[data-sel-role="vanityUrls"]').should(isVisible ? 'be.visible' : 'not.be.visible')
+        cy.get('button[data-sel-role="vanityUrls"]').should(isVisible ? 'exist' : 'not.exist')
     }
 }


### PR DESCRIPTION
### Description

Use exist instead of be.visible for the new vanity URLs button in CE to fix the integration tests.
Local run was green for both permission tests using isVisible(true) or (false).

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
