### PR TITLE
test: fix move vanity URLs tests

### DIFF
--- a/tests/cypress/e2e/move/checkMoveAction.cy.ts
+++ b/tests/cypress/e2e/move/checkMoveAction.cy.ts
@@ -73,6 +73,8 @@ describe('Checks the publication action on not published pages in UIs', () => {
         const vanityUrlRow = sourcePageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-to-move-a')
         const menu = vanityUrlRow.openContextualMenu()
         const picker = menu.clickOnMove()
+
+        cy.get('li[data-sel-role="home"]').click()
         picker.getTable().getRowByLabel(targetPageName).click()
         picker.select()
 
@@ -101,6 +103,7 @@ describe('Checks the publication action on not published pages in UIs', () => {
         const toolbar = vanityUrlsPage.getToolbar()
         const picker = toolbar.clickOnMove()
 
+        cy.get('li[data-sel-role="home"]').click()
         picker.getTable().getRowByLabel(targetPageName).click()
         picker.select()
 


### PR DESCRIPTION
### Description
Added a step to click on home page before clicking on sub-page "targetPage" as it was not showing in the picker.


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
