### PR TITLE
fix: Fix modal height between no vanity and vanity

### DIFF
--- a/src/javascript/components/contentEditor/SiteSettingsSeo/SiteSettingsSeoCardApp.scss
+++ b/src/javascript/components/contentEditor/SiteSettingsSeo/SiteSettingsSeoCardApp.scss
@@ -18,7 +18,8 @@
 }
 
 .dropdownDiv {
-    margin-top: 8px
+    margin-top: 8px;
+    min-height: 32px;
 }
 
 .root > div > div > div > div > div{


### PR DESCRIPTION
### Description
- Make modal height the same when there is no vanity created and when there are some

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
