### PR TITLE
fix: Set description length to 240 for main resource

### DIFF
--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_mainResource_rename_description.json
@@ -17,7 +17,7 @@
               "labelKey": "site-settings-seo:seo.metaDescription.label",
               "descriptionKey": "site-settings-seo:seo.metaDescription.ui.tooltip",
               "selectorOptionsMap": {
-                "maxLength": 160
+                "maxLength": 240
               }
             },
             {


### PR DESCRIPTION
### Description
Set meta description length to 240 for main resource. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
