### PR TITLE
test: add vanity url tests inside dashboard

### DIFF
--- a/src/javascript/components/SearchBar.jsx
+++ b/src/javascript/components/SearchBar.jsx
@@ -96,6 +96,7 @@ class SearchBarCmp extends React.Component {
                 disableUnderline
                 classes={{root: (this.state.focus ? classes.rootFocus : classes.root), input: (this.state.focus ? null : classes.input)}}
                 type="text"
+                inputProps={{'data-sel-role': 'vanity-search'}}
                 inputRef={input => {
                     this.inputSearchBar = input;
                 }}

--- a/tests/cypress/e2e/dashboard/checkDisplayedVanity.test.cy.ts
+++ b/tests/cypress/e2e/dashboard/checkDisplayedVanity.test.cy.ts
@@ -1,7 +1,7 @@
 import { publishAndWaitJobEnding, unpublishNode, createSite, deleteSite, addVanityUrl } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
 
-describe('Checks on vanity urls dashboard', () => {
+describe('Checks on vanity urls in dashboard', () => {
     const siteKey = 'testSite'
     const sitePath = '/sites/' + siteKey
     const homePath = sitePath + '/home'
@@ -16,9 +16,10 @@ describe('Checks on vanity urls dashboard', () => {
     }
 
     let pageId
+    const pages: Record<string, string> = {}
 
     const createPage = (parent: string, name: string, template: string, lang: string) => {
-        cy.apollo({
+        return cy.apollo({
             variables: {
                 parentPathOrId: parent,
                 name: name,
@@ -28,6 +29,7 @@ describe('Checks on vanity urls dashboard', () => {
             mutationFile: 'graphql/jcrAddPage.graphql',
         }).then((res) => {
             pageId = res.data.jcr.addNode.uuid
+            return res
         })
     }
 
@@ -38,17 +40,51 @@ describe('Checks on vanity urls dashboard', () => {
         addVanityUrl(pagePath, 'en', 'vanity-a')
         addVanityUrl(pagePath, 'en', 'vanity-b')
         publishAndWaitJobEnding(pagePath, [langEN])
+
+        // Page for: search
+        cy.apollo({
+            variables: {
+                parentPathOrId: homePath,
+                name: 'pageSearch',
+                template: 'default',
+                language: langEN,
+            },
+            mutationFile: 'graphql/jcrAddPage.graphql',
+        }).then((res) => {
+            pages['pageSearch'] = res.data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageSearch', langEN, 'unique-search-term')
+        addVanityUrl(homePath + '/pageSearch', langEN, 'other-vanity')
+        publishAndWaitJobEnding(homePath + '/pageSearch', [langEN])
     })
 
     after('clear test data', function () {
         deleteSite(siteKey)
     })
 
-    it('Verify content correctly displayed for pages with unpublished publication status.', function () {
+    it('verify content correctly displayed for pages with unpublished publication status.', function () {
         cy.login()
         unpublishNode(pagePath, langEN)
         const vanityUrlsPage = VanityUrlsPage.visit(siteKey, 'en')
         vanityUrlsPage.openPageVanityUrlsList(pageName)
         vanityUrlsPage.findVanityUrlsTable(pageId).should('exist')
+    })
+
+    it('should display a published vanity url in the dashboard', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pageId)
+        pageCard.open()
+        pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-a').get().should('exist')
+    })
+
+    it('should find the vanity url when searching', function () {
+        cy.login()
+        VanityUrlsPage.visit(siteKey, langEN)
+
+        cy.get('input[type="text"]').first().type('unique-search-term')
+
+        cy.get('[data-sel-role="pages-with-vanity"]').should('exist')
+        cy.get(`[data-vud-content-uuid="${pages['pageSearch']}"]`).should('exist')
     })
 })

--- a/tests/cypress/e2e/dashboard/checkDisplayedVanity.test.cy.ts
+++ b/tests/cypress/e2e/dashboard/checkDisplayedVanity.test.cy.ts
@@ -1,5 +1,6 @@
 import { publishAndWaitJobEnding, unpublishNode, createSite, deleteSite, addVanityUrl } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+import { addSimplePage } from '../../utils/Utils'
 
 describe('Checks on vanity urls in dashboard', () => {
     const siteKey = 'testSite'
@@ -15,45 +16,22 @@ describe('Checks on vanity urls in dashboard', () => {
         locale: langEN,
     }
 
-    let pageId
+    let pageId: string
     const pages: Record<string, string> = {}
-
-    const createPage = (parent: string, name: string, template: string, lang: string) => {
-        return cy
-            .apollo({
-                variables: {
-                    parentPathOrId: parent,
-                    name: name,
-                    template: template,
-                    language: lang,
-                },
-                mutationFile: 'graphql/jcrAddPage.graphql',
-            })
-            .then((res) => {
-                pageId = res.data.jcr.addNode.uuid
-                return res
-            })
-    }
 
     before('create test data', function () {
         createSite(siteKey, siteConfig)
-        createPage(homePath, pageName, 'default', langEN)
+        addSimplePage(homePath, pageName, pageName, langEN, 'default').then(({ data }) => {
+            pageId = data.jcr.addNode.uuid
+        })
 
         addVanityUrl(pagePath, 'en', 'vanity-a')
         addVanityUrl(pagePath, 'en', 'vanity-b')
         publishAndWaitJobEnding(pagePath, [langEN])
 
         // Page for: search
-        cy.apollo({
-            variables: {
-                parentPathOrId: homePath,
-                name: 'pageSearch',
-                template: 'default',
-                language: langEN,
-            },
-            mutationFile: 'graphql/jcrAddPage.graphql',
-        }).then((res) => {
-            pages['pageSearch'] = res.data.jcr.addNode.uuid
+        addSimplePage(homePath, 'pageSearch', 'pageSearch', langEN, 'default').then(({ data }) => {
+            pages['pageSearch'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageSearch', langEN, 'unique-search-term')
         addVanityUrl(homePath + '/pageSearch', langEN, 'other-vanity')
@@ -82,11 +60,12 @@ describe('Checks on vanity urls in dashboard', () => {
 
     it('should find the vanity url when searching', function () {
         cy.login()
-        VanityUrlsPage.visit(siteKey, langEN)
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
 
-        cy.get('input[type="text"]').first().type('unique-search-term')
+        vanityUrlsPage.getSearchBar().search('unique-search-term')
 
-        cy.get('[data-sel-role="pages-with-vanity"]').should('exist')
-        cy.get(`[data-vud-content-uuid="${pages['pageSearch']}"]`).should('exist')
+        const pagesWithVanityUrl = vanityUrlsPage.getPagesWithVanityUrl()
+        pagesWithVanityUrl.get().should('exist')
+        pagesWithVanityUrl.getPageCard(pages['pageSearch']).get().should('exist')
     })
 })

--- a/tests/cypress/e2e/dashboard/checkDisplayedVanity.test.cy.ts
+++ b/tests/cypress/e2e/dashboard/checkDisplayedVanity.test.cy.ts
@@ -19,18 +19,20 @@ describe('Checks on vanity urls in dashboard', () => {
     const pages: Record<string, string> = {}
 
     const createPage = (parent: string, name: string, template: string, lang: string) => {
-        return cy.apollo({
-            variables: {
-                parentPathOrId: parent,
-                name: name,
-                template: template,
-                language: lang,
-            },
-            mutationFile: 'graphql/jcrAddPage.graphql',
-        }).then((res) => {
-            pageId = res.data.jcr.addNode.uuid
-            return res
-        })
+        return cy
+            .apollo({
+                variables: {
+                    parentPathOrId: parent,
+                    name: name,
+                    template: template,
+                    language: lang,
+                },
+                mutationFile: 'graphql/jcrAddPage.graphql',
+            })
+            .then((res) => {
+                pageId = res.data.jcr.addNode.uuid
+                return res
+            })
     }
 
     before('create test data', function () {

--- a/tests/cypress/e2e/dashboard/checkSorting.cy.ts
+++ b/tests/cypress/e2e/dashboard/checkSorting.cy.ts
@@ -1,4 +1,4 @@
-import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl } from '@jahia/cypress'
+import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl, setNodeProperty } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
 
 describe('Checks the sort of pages in dashboard', () => {
@@ -7,16 +7,19 @@ describe('Checks the sort of pages in dashboard', () => {
     const homePath = sitePath + '/home'
     const prefixPageName = 'testPage'
     const langEN = 'en'
+    const langFR = 'fr'
     const siteConfig = {
-        languages: langEN,
+        languages: langEN + ',' + langFR,
         templateSet: 'dx-base-demo-templates',
         serverName: 'localhost',
         locale: langEN,
     }
     const letterList = ['a', '2', 'b2', 'c', 'v', 'e', 'f', 'p', 'h', 'x', 'j', '1', 'C1', 'C3', 'c2']
 
+    const pages: Record<string, string> = {}
+
     const createPage = (parent: string, name: string, template: string, lang: string) => {
-        cy.apollo({
+        return cy.apollo({
             variables: {
                 parentPathOrId: parent,
                 name: name,
@@ -36,22 +39,82 @@ describe('Checks the sort of pages in dashboard', () => {
             addVanityUrl(pagePath, 'en', `vanity-${letter}`)
             publishAndWaitJobEnding(pagePath, [langEN])
         })
+
+        // Page for: filter by language
+        createPage(homePath, 'pageFilter', 'default', langEN).then(({ data }) => {
+            pages['pageFilter'] = data.jcr.addNode.uuid
+        })
+        setNodeProperty(homePath + '/pageFilter', 'jcr:title', 'pageFilter-fr', langFR)
+        addVanityUrl(homePath + '/pageFilter', langEN, 'vanity-english')
+        addVanityUrl(homePath + '/pageFilter', langFR, 'vanity-french')
+        publishAndWaitJobEnding(homePath + '/pageFilter', [langEN, langFR])
+
+        // Page for: staging/live and non-published in live
+        createPage(homePath, 'pageLive', 'default', langEN).then(({ data }) => {
+            pages['pageLive'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageLive', langEN, 'vanity-published')
+        publishAndWaitJobEnding(homePath + '/pageLive', [langEN])
+        addVanityUrl(homePath + '/pageLive', langEN, 'vanity-not-published')
     })
 
     after('clear test data', function () {
         deleteSite(siteKey)
     })
 
-    it('Check if pages are sorted by name.', function () {
+    it('check if pages are sorted by name.', function () {
         cy.login()
         const vanityUrlsPage = VanityUrlsPage.visit(siteKey, 'en')
         const pagesWithVanityUrl = vanityUrlsPage.getPagesWithVanityUrl().items()
 
         pagesWithVanityUrl.should('have.length', 10)
 
-        const sortedLetters = letterList.sort(Intl.Collator().compare)
+        const allPageNames = [
+            ...letterList.map((letter) => `${prefixPageName}-${letter}`),
+            'pageFilter',
+            'pageLive',
+        ].sort(Intl.Collator().compare)
+
         pagesWithVanityUrl.each((page, index) => {
-            cy.wrap(page).should('contain', `testPage-${sortedLetters[index]}`)
+            cy.wrap(page).should('contain', allPageNames[index])
         })
+    })
+
+    it('should filter vanity urls by French language', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+
+        cy.get('[data-vud-role="language-selector"]').click()
+        cy.get('[data-vud-role="language-selector-item-all"]').click()
+        cy.get('[data-vud-role="language-selector-item"]').contains('en').click()
+        cy.get('body').click(0, 0)
+
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageFilter'])
+        pageCard.open()
+        pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-french').get().should('exist')
+    })
+
+    it('should display the live vanity URLs section when switching to staging and live', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageLive'])
+        pageCard.open()
+
+        vanityUrlsPage.switchToStagingAndLiveMode()
+
+        pageCard.getLiveVanityUrls().get().should('exist')
+        pageCard.getLiveVanityUrls().getVanityUrlRow('/vanity-published').get().should('exist')
+    })
+
+    it('should not display the non-published vanity url in live mode', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageLive'])
+        pageCard.open()
+
+        vanityUrlsPage.switchToLiveMode()
+
+        pageCard.getLiveVanityUrls().get().should('exist')
+        pageCard.getLiveVanityUrls().get().find('td').contains('/vanity-not-published').should('not.exist')
     })
 })

--- a/tests/cypress/e2e/dashboard/checkSorting.cy.ts
+++ b/tests/cypress/e2e/dashboard/checkSorting.cy.ts
@@ -1,5 +1,6 @@
 import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl, setNodeProperty } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+import { addSimplePage } from '../../utils/Utils'
 
 describe('Checks the sort of pages in dashboard', () => {
     const siteKey = 'testSort'
@@ -18,30 +19,18 @@ describe('Checks the sort of pages in dashboard', () => {
 
     const pages: Record<string, string> = {}
 
-    const createPage = (parent: string, name: string, template: string, lang: string) => {
-        return cy.apollo({
-            variables: {
-                parentPathOrId: parent,
-                name: name,
-                template: template,
-                language: lang,
-            },
-            mutationFile: 'graphql/jcrAddPage.graphql',
-        })
-    }
-
     before('create test data', function () {
         createSite(siteKey, siteConfig)
         letterList.forEach((letter) => {
             const pageName = `${prefixPageName}-${letter}`
             const pagePath = homePath + '/' + pageName
-            createPage(homePath, pageName, 'default', langEN)
+            addSimplePage(homePath, pageName, pageName, langEN, 'default')
             addVanityUrl(pagePath, 'en', `vanity-${letter}`)
             publishAndWaitJobEnding(pagePath, [langEN])
         })
 
         // Page for: filter by language
-        createPage(homePath, 'pageFilter', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageFilter', 'pageFilter', langEN, 'default').then(({ data }) => {
             pages['pageFilter'] = data.jcr.addNode.uuid
         })
         setNodeProperty(homePath + '/pageFilter', 'jcr:title', 'pageFilter-fr', langFR)
@@ -50,7 +39,7 @@ describe('Checks the sort of pages in dashboard', () => {
         publishAndWaitJobEnding(homePath + '/pageFilter', [langEN, langFR])
 
         // Page for: staging/live and non-published in live
-        createPage(homePath, 'pageLive', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageLive', 'pageLive', langEN, 'default').then(({ data }) => {
             pages['pageLive'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageLive', langEN, 'vanity-published')
@@ -84,10 +73,8 @@ describe('Checks the sort of pages in dashboard', () => {
         cy.login()
         const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
 
-        cy.get('[data-vud-role="language-selector"]').click()
-        cy.get('[data-vud-role="language-selector-item-all"]').click()
-        cy.get('[data-vud-role="language-selector-item"]').contains('en').click()
-        cy.get('body').click(0, 0)
+        const languageSelector = vanityUrlsPage.getLanguageSelector()
+        languageSelector.filterByLanguages('en')
 
         const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageFilter'])
         pageCard.open()

--- a/tests/cypress/e2e/dashboard/deleteAndMove.cy.ts
+++ b/tests/cypress/e2e/dashboard/deleteAndMove.cy.ts
@@ -1,10 +1,4 @@
-import {
-    publishAndWaitJobEnding,
-    createSite,
-    deleteSite,
-    addVanityUrl,
-    getComponent,
-} from '@jahia/cypress'
+import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl, getComponent } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
 import { MoveValidationDialog } from '../../page-object/components/dialog/MoveValidationDialog'
 

--- a/tests/cypress/e2e/dashboard/deleteAndMove.cy.ts
+++ b/tests/cypress/e2e/dashboard/deleteAndMove.cy.ts
@@ -1,0 +1,119 @@
+import {
+    publishAndWaitJobEnding,
+    createSite,
+    deleteSite,
+    addVanityUrl,
+    getComponent,
+} from '@jahia/cypress'
+import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+import { MoveValidationDialog } from '../../page-object/components/dialog/MoveValidationDialog'
+
+describe('Delete and move vanity URLs in dashboard', () => {
+    const siteKey = 'testDeleteMoveDashboard'
+    const sitePath = '/sites/' + siteKey
+    const homePath = sitePath + '/home'
+    const langEN = 'en'
+    const siteConfig = {
+        languages: langEN,
+        templateSet: 'dx-base-demo-templates',
+        serverName: 'localhost',
+        locale: langEN,
+    }
+
+    const pages: Record<string, string> = {}
+
+    const createPage = (parent: string, name: string, template: string, lang: string) => {
+        return cy.apollo({
+            variables: {
+                parentPathOrId: parent,
+                name: name,
+                template: template,
+                language: lang,
+            },
+            mutationFile: 'graphql/jcrAddPage.graphql',
+        })
+    }
+
+    before('Create site and test data', function () {
+        createSite(siteKey, siteConfig)
+
+        // Page for: delete and bulk delete
+        createPage(homePath, 'pageDelete', 'default', langEN).then(({ data }) => {
+            pages['pageDelete'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageDelete', langEN, 'vanity-to-delete')
+        addVanityUrl(homePath + '/pageDelete', langEN, 'vanity-bulk-delete-a')
+        addVanityUrl(homePath + '/pageDelete', langEN, 'vanity-bulk-delete-b')
+        publishAndWaitJobEnding(homePath + '/pageDelete', [langEN])
+
+        // Pages for: move vanity
+        createPage(homePath, 'pageMove', 'default', langEN).then(({ data }) => {
+            pages['pageMove'] = data.jcr.addNode.uuid
+        })
+        createPage(homePath, 'targetPage', 'default', langEN).then(({ data }) => {
+            pages['targetPage'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageMove', langEN, 'vanity-to-move')
+        publishAndWaitJobEnding(homePath + '/pageMove', [langEN])
+        publishAndWaitJobEnding(homePath + '/targetPage', [langEN])
+    })
+
+    after('Delete site', function () {
+        deleteSite(siteKey)
+    })
+
+    it('should delete a vanity url from the contextual menu', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageDelete'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-to-delete')
+        const menu = vanityUrlRow.openContextualMenu()
+        const deleteDialog = menu.clickOnDelete()
+        deleteDialog.markForDeletion()
+
+        pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-to-delete').getMarkForDeletionBadge().should('exist')
+    })
+
+    it('should delete multiple selected vanity urls', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageDelete'])
+        pageCard.open()
+
+        const stagingVanityUrls = pageCard.getStagingVanityUrls()
+        stagingVanityUrls.getVanityUrlRow('/vanity-bulk-delete-a').select()
+        stagingVanityUrls.getVanityUrlRow('/vanity-bulk-delete-b').select()
+
+        const toolbar = vanityUrlsPage.getToolbar()
+        const deleteDialog = toolbar.clickOnDelete()
+        deleteDialog.markForDeletion()
+
+        stagingVanityUrls.getVanityUrlRow('/vanity-bulk-delete-a').getMarkForDeletionBadge().should('exist')
+        stagingVanityUrls.getVanityUrlRow('/vanity-bulk-delete-b').getMarkForDeletionBadge().should('exist')
+    })
+
+    it('should move the vanity url to another page', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageMove'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-to-move')
+        const menu = vanityUrlRow.openContextualMenu()
+        const picker = menu.clickOnMove()
+
+        cy.get('li[data-sel-role="home"]').click()
+        picker.getTable().getRowByLabel('targetPage').click()
+        picker.select()
+
+        const moveValidationDialog = getComponent(MoveValidationDialog)
+        moveValidationDialog.move()
+
+        const targetPageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['targetPage'])
+        targetPageCard.open()
+        targetPageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-to-move').get().should('exist')
+    })
+})

--- a/tests/cypress/e2e/dashboard/deleteAndMove.cy.ts
+++ b/tests/cypress/e2e/dashboard/deleteAndMove.cy.ts
@@ -1,6 +1,7 @@
 import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl, getComponent } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
 import { MoveValidationDialog } from '../../page-object/components/dialog/MoveValidationDialog'
+import { addSimplePage } from '../../utils/Utils'
 
 describe('Delete and move vanity URLs in dashboard', () => {
     const siteKey = 'testDeleteMoveDashboard'
@@ -16,23 +17,11 @@ describe('Delete and move vanity URLs in dashboard', () => {
 
     const pages: Record<string, string> = {}
 
-    const createPage = (parent: string, name: string, template: string, lang: string) => {
-        return cy.apollo({
-            variables: {
-                parentPathOrId: parent,
-                name: name,
-                template: template,
-                language: lang,
-            },
-            mutationFile: 'graphql/jcrAddPage.graphql',
-        })
-    }
-
     before('Create site and test data', function () {
         createSite(siteKey, siteConfig)
 
         // Page for: delete and bulk delete
-        createPage(homePath, 'pageDelete', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageDelete', 'pageDelete', langEN, 'default').then(({ data }) => {
             pages['pageDelete'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageDelete', langEN, 'vanity-to-delete')
@@ -41,10 +30,10 @@ describe('Delete and move vanity URLs in dashboard', () => {
         publishAndWaitJobEnding(homePath + '/pageDelete', [langEN])
 
         // Pages for: move vanity
-        createPage(homePath, 'pageMove', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageMove', 'pageMove', langEN, 'default').then(({ data }) => {
             pages['pageMove'] = data.jcr.addNode.uuid
         })
-        createPage(homePath, 'targetPage', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'targetPage', 'targetPage', langEN, 'default').then(({ data }) => {
             pages['targetPage'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageMove', langEN, 'vanity-to-move')

--- a/tests/cypress/e2e/dashboard/publication.cy.ts
+++ b/tests/cypress/e2e/dashboard/publication.cy.ts
@@ -1,9 +1,4 @@
-import {
-    publishAndWaitJobEnding,
-    createSite,
-    deleteSite,
-    addVanityUrl,
-} from '@jahia/cypress'
+import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
 
 describe('Publish vanity URLs in dashboard', () => {

--- a/tests/cypress/e2e/dashboard/publication.cy.ts
+++ b/tests/cypress/e2e/dashboard/publication.cy.ts
@@ -1,5 +1,6 @@
 import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+import { addSimplePage } from '../../utils/Utils'
 
 describe('Publish vanity URLs in dashboard', () => {
     const siteKey = 'testPublishDashboard'
@@ -15,23 +16,11 @@ describe('Publish vanity URLs in dashboard', () => {
 
     const pages: Record<string, string> = {}
 
-    const createPage = (parent: string, name: string, template: string, lang: string) => {
-        return cy.apollo({
-            variables: {
-                parentPathOrId: parent,
-                name: name,
-                template: template,
-                language: lang,
-            },
-            mutationFile: 'graphql/jcrAddPage.graphql',
-        })
-    }
-
     before('Create site and test data', function () {
         createSite(siteKey, siteConfig)
 
         // Page for: publish and bulk publish
-        createPage(homePath, 'pagePublish', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pagePublish', 'pagePublish', langEN, 'default').then(({ data }) => {
             pages['pagePublish'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pagePublish', langEN, 'vanity-to-publish')

--- a/tests/cypress/e2e/dashboard/publication.cy.ts
+++ b/tests/cypress/e2e/dashboard/publication.cy.ts
@@ -1,0 +1,88 @@
+import {
+    publishAndWaitJobEnding,
+    createSite,
+    deleteSite,
+    addVanityUrl,
+} from '@jahia/cypress'
+import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+
+describe('Publish vanity URLs in dashboard', () => {
+    const siteKey = 'testPublishDashboard'
+    const sitePath = '/sites/' + siteKey
+    const homePath = sitePath + '/home'
+    const langEN = 'en'
+    const siteConfig = {
+        languages: langEN,
+        templateSet: 'dx-base-demo-templates',
+        serverName: 'localhost',
+        locale: langEN,
+    }
+
+    const pages: Record<string, string> = {}
+
+    const createPage = (parent: string, name: string, template: string, lang: string) => {
+        return cy.apollo({
+            variables: {
+                parentPathOrId: parent,
+                name: name,
+                template: template,
+                language: lang,
+            },
+            mutationFile: 'graphql/jcrAddPage.graphql',
+        })
+    }
+
+    before('Create site and test data', function () {
+        createSite(siteKey, siteConfig)
+
+        // Page for: publish and bulk publish
+        createPage(homePath, 'pagePublish', 'default', langEN).then(({ data }) => {
+            pages['pagePublish'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pagePublish', langEN, 'vanity-to-publish')
+        publishAndWaitJobEnding(homePath + '/pagePublish', [langEN])
+        addVanityUrl(homePath + '/pagePublish', langEN, 'vanity-unpublished')
+        addVanityUrl(homePath + '/pagePublish', langEN, 'vanity-bulk-pub-new-a')
+        addVanityUrl(homePath + '/pagePublish', langEN, 'vanity-bulk-pub-new-b')
+    })
+
+    after('Delete site', function () {
+        deleteSite(siteKey)
+    })
+
+    it('should publish a vanity url from the contextual menu', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pagePublish'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-unpublished')
+        const menu = vanityUrlRow.openContextualMenu()
+        const publishDialog = menu.clickOnPublish()
+        publishDialog.publish()
+
+        vanityUrlsPage.switchToStagingAndLiveMode()
+        pageCard.getLiveVanityUrls().getVanityUrlRow('/vanity-unpublished').get().should('exist')
+    })
+
+    it('should publish multiple selected vanity urls', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pagePublish'])
+        pageCard.open()
+
+        const stagingVanityUrls = pageCard.getStagingVanityUrls()
+        stagingVanityUrls.getVanityUrlRow('/vanity-bulk-pub-new-a').select()
+        stagingVanityUrls.getVanityUrlRow('/vanity-bulk-pub-new-b').select()
+
+        const toolbar = vanityUrlsPage.getToolbar()
+        const publishDialog = toolbar.clickOnPublish()
+        publishDialog.publish()
+
+        toolbar.close()
+
+        vanityUrlsPage.switchToStagingAndLiveMode()
+        pageCard.getLiveVanityUrls().getVanityUrlRow('/vanity-bulk-pub-new-a').get().should('exist')
+        pageCard.getLiveVanityUrls().getVanityUrlRow('/vanity-bulk-pub-new-b').get().should('exist')
+    })
+})

--- a/tests/cypress/e2e/dashboard/vanityUrlDashboard.cy.ts
+++ b/tests/cypress/e2e/dashboard/vanityUrlDashboard.cy.ts
@@ -1,10 +1,4 @@
-import {
-    publishAndWaitJobEnding,
-    createSite,
-    deleteSite,
-    addVanityUrl,
-    setNodeProperty,
-} from '@jahia/cypress'
+import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl, setNodeProperty } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
 
 describe('Vanity URL dashboard tests', () => {
@@ -170,6 +164,10 @@ describe('Vanity URL dashboard tests', () => {
         const vanityUrlsPageFr = VanityUrlsPage.visit(siteKey, langFR)
         const pageCardFr = vanityUrlsPageFr.getPagesWithVanityUrl().getPageCard(pages['pageLang'])
         pageCardFr.open()
-        pageCardFr.getStagingVanityUrls().getVanityUrlRow('/vanity-canonical-lang').getCanonicalBadge().should('not.exist')
+        pageCardFr
+            .getStagingVanityUrls()
+            .getVanityUrlRow('/vanity-canonical-lang')
+            .getCanonicalBadge()
+            .should('not.exist')
     })
 })

--- a/tests/cypress/e2e/dashboard/vanityUrlDashboard.cy.ts
+++ b/tests/cypress/e2e/dashboard/vanityUrlDashboard.cy.ts
@@ -1,0 +1,175 @@
+import {
+    publishAndWaitJobEnding,
+    createSite,
+    deleteSite,
+    addVanityUrl,
+    setNodeProperty,
+} from '@jahia/cypress'
+import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+
+describe('Vanity URL dashboard tests', () => {
+    const siteKey = 'testDashboardVanity'
+    const sitePath = '/sites/' + siteKey
+    const homePath = sitePath + '/home'
+    const langEN = 'en'
+    const langFR = 'fr'
+    const languages = langEN + ',' + langFR
+    const siteConfig = {
+        languages: languages,
+        templateSet: 'dx-base-demo-templates',
+        serverName: 'localhost',
+        locale: langEN,
+    }
+
+    const pages: Record<string, string> = {}
+
+    const createPage = (parent: string, name: string, template: string, lang: string) => {
+        return cy.apollo({
+            variables: {
+                parentPathOrId: parent,
+                name: name,
+                template: template,
+                language: lang,
+            },
+            mutationFile: 'graphql/jcrAddPage.graphql',
+        })
+    }
+
+    before('Create site and test data', function () {
+        createSite(siteKey, siteConfig)
+
+        // Page for: display, activate/deactivate
+        createPage(homePath, 'pageReadOnly', 'default', langEN).then(({ data }) => {
+            pages['pageReadOnly'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageReadOnly', langEN, 'vanity-dashboard')
+        addVanityUrl(homePath + '/pageReadOnly', langEN, 'vanity-active-toggle')
+        publishAndWaitJobEnding(homePath + '/pageReadOnly', [langEN])
+
+        // Page for: add vanity
+        createPage(homePath, 'pageAdd', 'default', langEN).then(({ data }) => {
+            pages['pageAdd'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageAdd', langEN, 'existing-vanity')
+        publishAndWaitJobEnding(homePath + '/pageAdd', [langEN])
+
+        // Page for: set canonical
+        createPage(homePath, 'pageSetCanonical', 'default', langEN).then(({ data }) => {
+            pages['pageSetCanonical'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageSetCanonical', langEN, 'vanity-not-canonical')
+        addVanityUrl(homePath + '/pageSetCanonical', langEN, 'vanity-canonical')
+        publishAndWaitJobEnding(homePath + '/pageSetCanonical', [langEN])
+
+        // Page for: unset canonical
+        createPage(homePath, 'pageUnsetCanonical', 'default', langEN).then(({ data }) => {
+            pages['pageUnsetCanonical'] = data.jcr.addNode.uuid
+        })
+        addVanityUrl(homePath + '/pageUnsetCanonical', langEN, 'vanity-is-canonical')
+        publishAndWaitJobEnding(homePath + '/pageUnsetCanonical', [langEN])
+
+        // Page for: change language and canonical + language change
+        createPage(homePath, 'pageLang', 'default', langEN).then(({ data }) => {
+            pages['pageLang'] = data.jcr.addNode.uuid
+        })
+        setNodeProperty(homePath + '/pageLang', 'jcr:title', 'pageLang-fr', langFR)
+        addVanityUrl(homePath + '/pageLang', langEN, 'vanity-lang-change')
+        addVanityUrl(homePath + '/pageLang', langEN, 'vanity-canonical-lang')
+        publishAndWaitJobEnding(homePath + '/pageLang', [langEN, langFR])
+    })
+
+    after('Delete site', function () {
+        deleteSite(siteKey)
+    })
+
+    it('should add a new vanity url from the dashboard', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageAdd'])
+        pageCard.open()
+
+        const addForm = pageCard.clickOnAddVanityUrl()
+        addForm.fillVanityValues('new-vanity-added')
+
+        pageCard.getStagingVanityUrls().getVanityUrlRow('/new-vanity-added').get().should('exist')
+    })
+
+    it('should set a vanity url as canonical via contextual menu', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageSetCanonical'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-not-canonical')
+        vanityUrlRow.getCanonicalBadge().should('not.exist')
+
+        const menu = vanityUrlRow.openContextualMenu()
+        menu.get().find('[data-sel-role="updateVanity"]').click()
+
+        pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-not-canonical').getCanonicalBadge().should('exist')
+    })
+
+    it('should unset a vanity url as canonical via contextual menu', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageUnsetCanonical'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-is-canonical')
+        vanityUrlRow.getCanonicalBadge().should('exist')
+
+        const menu = vanityUrlRow.openContextualMenu()
+        menu.get().find('[data-sel-role="updateVanity"]').click()
+
+        pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-is-canonical').getCanonicalBadge().should('not.exist')
+    })
+
+    it('should deactivate and reactivate a vanity url', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageReadOnly'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-active-toggle')
+
+        vanityUrlRow.getActiveSwitch().should('be.checked')
+
+        vanityUrlRow.toggleActive()
+        vanityUrlRow.getActiveSwitch().should('not.be.checked')
+
+        vanityUrlRow.toggleActive()
+        vanityUrlRow.getActiveSwitch().should('be.checked')
+    })
+
+    it('should change the language of a vanity url', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageLang'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-lang-change')
+        vanityUrlRow.changeLanguage(langFR)
+
+        const vanityUrlsPageFr = VanityUrlsPage.visit(siteKey, langFR)
+        const pageCardFr = vanityUrlsPageFr.getPagesWithVanityUrl().getPageCard(pages['pageLang'])
+        pageCardFr.open()
+        pageCardFr.getStagingVanityUrls().getVanityUrlRow('/vanity-lang-change').get().should('exist')
+    })
+
+    it('should remove canonical when changing the language of a canonical vanity url', function () {
+        cy.login()
+        const vanityUrlsPage = VanityUrlsPage.visit(siteKey, langEN)
+        const pageCard = vanityUrlsPage.getPagesWithVanityUrl().getPageCard(pages['pageLang'])
+        pageCard.open()
+
+        const vanityUrlRow = pageCard.getStagingVanityUrls().getVanityUrlRow('/vanity-canonical-lang')
+        vanityUrlRow.getCanonicalBadge().should('exist')
+
+        vanityUrlRow.changeLanguage(langFR)
+
+        const vanityUrlsPageFr = VanityUrlsPage.visit(siteKey, langFR)
+        const pageCardFr = vanityUrlsPageFr.getPagesWithVanityUrl().getPageCard(pages['pageLang'])
+        pageCardFr.open()
+        pageCardFr.getStagingVanityUrls().getVanityUrlRow('/vanity-canonical-lang').getCanonicalBadge().should('not.exist')
+    })
+})

--- a/tests/cypress/e2e/dashboard/vanityUrlDashboard.cy.ts
+++ b/tests/cypress/e2e/dashboard/vanityUrlDashboard.cy.ts
@@ -1,5 +1,6 @@
 import { publishAndWaitJobEnding, createSite, deleteSite, addVanityUrl, setNodeProperty } from '@jahia/cypress'
 import { VanityUrlsPage } from '../../page-object/vanityUrls.page'
+import { addSimplePage } from '../../utils/Utils'
 
 describe('Vanity URL dashboard tests', () => {
     const siteKey = 'testDashboardVanity'
@@ -17,23 +18,11 @@ describe('Vanity URL dashboard tests', () => {
 
     const pages: Record<string, string> = {}
 
-    const createPage = (parent: string, name: string, template: string, lang: string) => {
-        return cy.apollo({
-            variables: {
-                parentPathOrId: parent,
-                name: name,
-                template: template,
-                language: lang,
-            },
-            mutationFile: 'graphql/jcrAddPage.graphql',
-        })
-    }
-
     before('Create site and test data', function () {
         createSite(siteKey, siteConfig)
 
         // Page for: display, activate/deactivate
-        createPage(homePath, 'pageReadOnly', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageReadOnly', 'pageReadOnly', langEN, 'default').then(({ data }) => {
             pages['pageReadOnly'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageReadOnly', langEN, 'vanity-dashboard')
@@ -41,14 +30,14 @@ describe('Vanity URL dashboard tests', () => {
         publishAndWaitJobEnding(homePath + '/pageReadOnly', [langEN])
 
         // Page for: add vanity
-        createPage(homePath, 'pageAdd', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageAdd', 'pageAdd', langEN, 'default').then(({ data }) => {
             pages['pageAdd'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageAdd', langEN, 'existing-vanity')
         publishAndWaitJobEnding(homePath + '/pageAdd', [langEN])
 
         // Page for: set canonical
-        createPage(homePath, 'pageSetCanonical', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageSetCanonical', 'pageSetCanonical', langEN, 'default').then(({ data }) => {
             pages['pageSetCanonical'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageSetCanonical', langEN, 'vanity-not-canonical')
@@ -56,14 +45,14 @@ describe('Vanity URL dashboard tests', () => {
         publishAndWaitJobEnding(homePath + '/pageSetCanonical', [langEN])
 
         // Page for: unset canonical
-        createPage(homePath, 'pageUnsetCanonical', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageUnsetCanonical', 'pageUnsetCanonical', langEN, 'default').then(({ data }) => {
             pages['pageUnsetCanonical'] = data.jcr.addNode.uuid
         })
         addVanityUrl(homePath + '/pageUnsetCanonical', langEN, 'vanity-is-canonical')
         publishAndWaitJobEnding(homePath + '/pageUnsetCanonical', [langEN])
 
         // Page for: change language and canonical + language change
-        createPage(homePath, 'pageLang', 'default', langEN).then(({ data }) => {
+        addSimplePage(homePath, 'pageLang', 'pageLang', langEN, 'default').then(({ data }) => {
             pages['pageLang'] = data.jcr.addNode.uuid
         })
         setNodeProperty(homePath + '/pageLang', 'jcr:title', 'pageLang-fr', langFR)

--- a/tests/cypress/page-object/components/AddVanityUrl.ts
+++ b/tests/cypress/page-object/components/AddVanityUrl.ts
@@ -19,12 +19,10 @@ export class AddVanityUrl extends BaseComponent {
 
         if (disabled) {
             this.get()
-                .get('div[data-sel-role="manage-vanity-url-dialog"]')
                 .find('button[data-vud-role="button-primary"]')
                 .should('be.disabled')
         } else {
             this.get()
-                .get('div[data-sel-role="manage-vanity-url-dialog"]')
                 .find('button[data-vud-role="button-primary"]')
                 .click()
         }

--- a/tests/cypress/page-object/components/AddVanityUrl.ts
+++ b/tests/cypress/page-object/components/AddVanityUrl.ts
@@ -18,13 +18,9 @@ export class AddVanityUrl extends BaseComponent {
             .click()
 
         if (disabled) {
-            this.get()
-                .find('button[data-vud-role="button-primary"]')
-                .should('be.disabled')
+            this.get().find('button[data-vud-role="button-primary"]').should('be.disabled')
         } else {
-            this.get()
-                .find('button[data-vud-role="button-primary"]')
-                .click()
+            this.get().find('button[data-vud-role="button-primary"]').click()
         }
     }
 }

--- a/tests/cypress/page-object/components/LanguageSelector.ts
+++ b/tests/cypress/page-object/components/LanguageSelector.ts
@@ -1,0 +1,33 @@
+import { BaseComponent } from '@jahia/cypress'
+
+export class LanguageSelector extends BaseComponent {
+    static defaultSelector = '[data-vud-role="language-selector"]'
+
+    open() {
+        this.get().click()
+        return this
+    }
+
+    selectAll() {
+        cy.get('[data-vud-role="language-selector-item-all"]').click()
+        return this
+    }
+
+    selectLanguage(lang: string) {
+        cy.get('[data-vud-role="language-selector-item"]').contains(lang).click()
+        return this
+    }
+
+    close() {
+        cy.get('body').click(0, 0)
+        return this
+    }
+
+    filterByLanguages(...languages: string[]) {
+        this.open()
+        this.selectAll()
+        languages.forEach((lang) => this.selectLanguage(lang))
+        this.close()
+        return this
+    }
+}

--- a/tests/cypress/page-object/components/SearchBar.ts
+++ b/tests/cypress/page-object/components/SearchBar.ts
@@ -1,0 +1,15 @@
+import { BaseComponent } from '@jahia/cypress'
+
+export class SearchBar extends BaseComponent {
+    static defaultSelector = 'input[type="text"]'
+
+    search(term: string) {
+        this.get().clear().type(term)
+        return this
+    }
+
+    clear() {
+        this.get().clear()
+        return this
+    }
+}

--- a/tests/cypress/page-object/components/VanityUrlRow.ts
+++ b/tests/cypress/page-object/components/VanityUrlRow.ts
@@ -30,6 +30,19 @@ export class VanityUrlRow extends BaseComponent {
         return this.get().find('div[data-sel-role="canonical-badge"]')
     }
 
+    getActiveSwitch() {
+        return this.get().find('[data-vud-role="action-active"] input')
+    }
+
+    toggleActive() {
+        this.get().find('[data-vud-role="action-active"] input').click()
+    }
+
+    changeLanguage(languageCode: string) {
+        this.get().find('[data-sel-role="vanity-language-menu"]').click()
+        cy.get(`li[data-sel-value="${languageCode}"]`).click()
+    }
+
     getError() {
         return getComponent(FieldError, this)
     }

--- a/tests/cypress/page-object/dashboard/Toolbar.ts
+++ b/tests/cypress/page-object/dashboard/Toolbar.ts
@@ -10,6 +10,10 @@ export class Toolbar extends BaseComponent {
         this.get().find('[data-jrm-role="table-pagination-button-next-page"]').click()
     }
 
+    close() {
+        this.get().find('[class*="Toolbar__clearButton"]').click()
+    }
+
     getMoveButton() {
         return this.get().find('[data-sel-role="moveVanity"]')
     }

--- a/tests/cypress/page-object/vanityUrls.page.ts
+++ b/tests/cypress/page-object/vanityUrls.page.ts
@@ -3,6 +3,8 @@ import { PageWithVanityUrlList } from './dashboard/PageWithVanityUrlList'
 import { Pagination } from './dashboard/Pagination'
 import { Toolbar } from './dashboard/Toolbar'
 import { StagingVanityUrlList } from './components/StagingVanityUrlList'
+import { SearchBar } from './components/SearchBar'
+import { LanguageSelector } from './components/LanguageSelector'
 
 export class VanityUrlsPage {
     elements = {
@@ -97,6 +99,14 @@ export class VanityUrlsPage {
 
     getToolbar(): Toolbar {
         return getComponent(Toolbar)
+    }
+
+    getSearchBar(): SearchBar {
+        return getComponent(SearchBar)
+    }
+
+    getLanguageSelector(): LanguageSelector {
+        return getComponent(LanguageSelector)
     }
 
     switchToStagingAndLiveMode() {


### PR DESCRIPTION
### Description
Add more tests in vanity URLs > dashboard.
It includes scenarios from the Selenium tests:
- testVanityUrlPublicationForPages
- testPublicationOnVanityUrlDashboard
- testPublishDeletedMappings
- testSetDefaultOnDashboard
- testSetActiveOnDashboard
- testSearchOnVanityUrlDashboard
- shouldAddOneOrMultipleVanityURLs
- shouldAddMultipleVanityUrls
- shouldOnlyAllowOneDefaultPerLanguageWhenAdding
- testFilteringByLanguage

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
